### PR TITLE
APPDEV-7507 adding CSV upload ability for ReelTapeNumber

### DIFF
--- a/app/Import/ItemsImport.php
+++ b/app/Import/ItemsImport.php
@@ -35,7 +35,7 @@ class ItemsImport extends Import {
     $this->itemsImportKeys = array_merge($this->requiredItemsImportKeys, 
       array('ContainerNote', 'LegacyID', 'RecLocation', 'ItemYear', 
         'ItemDate', 'Size', 'Element', 'Base', 'Color', 'SoundType', 
-        'LengthInFeet', 'ContentDescription'));
+        'LengthInFeet', 'ContentDescription', 'ReelTapeNumber'));
 
     $this->solrItems = new SolariumProxy('jitterbug-items');
 
@@ -211,6 +211,8 @@ class ItemsImport extends Import {
           isset($row['ItemYear']) ? $row['ItemYear'] : null;
         $item->itemDate = 
           isset($row['ItemDate']) ? $row['ItemDate'] : null;
+        $item->reelTapeNumber =
+          isset($row['ReelTapeNumber']) ? $row['ReelTapeNumber'] : null;
         $item->save();
         $created++;
 

--- a/resources/views/items/_items-import-table-header.blade.php
+++ b/resources/views/items/_items-import-table-header.blade.php
@@ -18,5 +18,6 @@
         <th width="5%">SoundType</th>
         <th width="6%">LengthInFeet</th>
         <th width="11%">ContentDescription</th>
+        <th width="5%">ReelTapeNumber</th>
       </tr>
     </thead>

--- a/resources/views/items/_items-import-table-header.blade.php
+++ b/resources/views/items/_items-import-table-header.blade.php
@@ -4,11 +4,11 @@
         <th width="3%">Type</th>
         <th width="9%">Title</th>
         <th width="5%">Collection</th>
-        <th width="10%">ContainerNote</th>
+        <th width="9%">ContainerNote</th>
         <th width="7%">AccessionNumber</th>
         <th width="4%">LegacyID</th>
-        <th width="5%">FormatID</th>
-        <th width="7%">RecLocation</th>
+        <th width="4%">FormatID</th>
+        <th width="6%">RecLocation</th>
         <th width="4%">ItemYear</th>       
         <th width="5%">ItemDate</th>
         <th width="4%">Size</th>
@@ -17,7 +17,7 @@
         <th width="4%">Color</th>
         <th width="5%">SoundType</th>
         <th width="6%">LengthInFeet</th>
-        <th width="11%">ContentDescription</th>
+        <th width="9%">ContentDescription</th>
         <th width="5%">ReelTapeNumber</th>
       </tr>
     </thead>

--- a/resources/views/items/_items-import-upload-data.blade.php
+++ b/resources/views/items/_items-import-upload-data.blade.php
@@ -29,6 +29,7 @@
         <td>{{isset($row['SoundType']) ? $row['SoundType'] : ''}}</td>
         <td>{{isset($row['LengthInFeet']) ? $row['LengthInFeet'] : ''}}</td>
         <td>{{isset($row['ContentDescription']) ? $row['ContentDescription'] : ''}}</td>
+        <td>{{isset($row['ReelTapeNumber']) ? $row['ReelTapeNumber'] : ''}}</td>
       </tr>
       <?php $index++; ?>
       @endforeach 


### PR DESCRIPTION
This allows for the ReelTapeNumber column to be populated by batch CSV upload.

The CSV preview now shows the column:
![Screen Shot 2019-03-15 at 9 42 01 AM](https://user-images.githubusercontent.com/6546457/54435605-42a58e00-4707-11e9-8c82-7661b10e4c9a.png)

The resulting item has the column populated:
![Screen Shot 2019-03-15 at 9 41 31 AM](https://user-images.githubusercontent.com/6546457/54435617-4802d880-4707-11e9-97d4-97e5684c363a.png)

I'm checking in about possible validations, but the upload works.