### PR TITLE
Appdev 8583 call number test

### DIFF
--- a/app/Models/CallNumberSequence.php
+++ b/app/Models/CallNumberSequence.php
@@ -10,7 +10,6 @@ class CallNumberSequence extends Model {
 
   public static function next($collectionId, $formatId)
   {
-    $collection = Collection::findOrFail($collectionId);
     $prefix = Format::findOrFail($formatId)->prefix;
 
     $sequence = NewCallNumberSequence::where('prefix', '=', $prefix)->

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,4 +16,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase {
 		return $app;
 	}
 
+	protected $connectionsToTransact = [
+	  'mysql'
+  ];
 }

--- a/tests/Unit/CallNumberSequenceTest.php
+++ b/tests/Unit/CallNumberSequenceTest.php
@@ -1,0 +1,39 @@
+<?php
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Jitterbug\Models as Models;
+
+class CallNumberSequenceTest extends TestCase
+
+{
+  use DatabaseTransactions;
+  /**
+   * A basic test example.
+   *
+   * @return void
+   */
+
+  public function testNextAlwaysUseNewCallSequence()
+  {
+    $new_prefix_array = Models\CallNumberSequence::ALWAYS_USE_NEW_STYLE;
+    $collection = factory(Models\Collection::class)->make();
+    $format = factory(Models\Format::class)->create([
+        'prefix' => $new_prefix_array[array_rand(@$new_prefix_array)],
+    ]);
+
+    $sequence = Models\CallNumberSequence::next($collection->id, $format->id);
+    $this->assertTrue(is_a($sequence,'Jitterbug\Models\NewCallNumberSequence'),
+      'Call Number is not a NewCallNumberSequence, as it should be.');
+  }
+
+  public function testNextFollowsPrecedingNewCallNumberSequence()
+  {
+
+  }
+
+  function isNewCallNumber($callNumber){
+    preg_match('/^\w*-\d*\/\d*$/', $callNumber);
+  }
+  function isLegacyCallNumber($callNumber){
+    preg_match('/^\w*-\d*$/', $callNumber);
+  }
+}

--- a/tests/Unit/CallNumberSequenceTest.php
+++ b/tests/Unit/CallNumberSequenceTest.php
@@ -12,20 +12,20 @@ class CallNumberSequenceTest extends TestCase
    * @return void
    */
 
-  public function testNextAlwaysUseNewCallSequence()
+  public function testNextAlwaysUsesNewCallSequenceIfPrefixInNewStyleArray()
   {
     $new_prefix_array = Models\CallNumberSequence::ALWAYS_USE_NEW_STYLE;
     $collectionId = 20005;
     $format = factory(Models\Format::class)->create([
-        'prefix' => $new_prefix_array[array_rand(@$new_prefix_array)],
+        'prefix' => $new_prefix_array[array_rand($new_prefix_array)],
     ]);
 
     $sequence = Models\CallNumberSequence::next($collectionId, $format->id);
     $this->assertTrue(is_a($sequence,'Jitterbug\Models\NewCallNumberSequence'),
-      'Call Number is not a NewCallNumberSequence, as it should be.');
+      'Sequence is not a NewCallNumberSequence, as it should be.');
   }
 
-  public function testNextReturnsPrecedingNewCallNumberSequence()
+  public function testNextReturnsNewCallNumberSequenceIfItAlreadyExists()
   {
     $collectionId = 20006;
     $callNumber = factory(Models\NewCallNumberSequence::class)->create([
@@ -39,10 +39,12 @@ class CallNumberSequenceTest extends TestCase
 
     $sequence = Models\CallNumberSequence::next($collectionId, $format->id);
     $this->assertSame($callNumber->id, $sequence->id,
-      'Call Number is not the existing last NewCallNumberSequence, as it should be.');
+      'Sequence is not the existing NewCallNumberSequence, as it should be.');
+    $this->assertTrue(is_a($sequence,'Jitterbug\Models\NewCallNumberSequence'),
+      'Sequence is not a NewCallNumberSequence, as it should be.');
   }
 
-  public function testNextReturnsPrecedingLegacyCallNumberSequence()
+  public function testNextReturnsExistingLegacyCallNumberSequenceIfNoNewCallNumberSequenceExists()
   {
     $collectionId = 20007;
     $prefix = 'CD';
@@ -51,7 +53,7 @@ class CallNumberSequenceTest extends TestCase
       'collectionId' => 20013,
       'next' => 2
     ]);
-    factory(Models\LegacyCallNumberSequence::class)->create([
+    $legacyCallNumber = factory(Models\LegacyCallNumberSequence::class)->create([
       'prefix' => $prefix,
       'next' => 2
     ]);
@@ -61,6 +63,8 @@ class CallNumberSequenceTest extends TestCase
 
     $sequence = Models\CallNumberSequence::next($collectionId, $format->id);
     $this->assertTrue(is_a($sequence,'Jitterbug\Models\LegacyCallNumberSequence'),
-      'Call Number is not a LegacyCallNumberSequence, as it should be.');
+      'Sequence is not a LegacyCallNumberSequence, as it should be.');
+    $this->assertSame($legacyCallNumber->id, $sequence->id,
+      'Sequence is not the existing legacyCallNumberSequence, as it should be.');
   }
 }


### PR DESCRIPTION
This PR adds a few tests for the `next` method in CallNumberSequences which has the logic for what type of call number should be used when creating a new item.