### PR TITLE
APPDEV-5886 DRYing up batch edit limit code, increasing to 1000, and …

### DIFF
--- a/app/Http/Controllers/MastersController.php
+++ b/app/Http/Controllers/MastersController.php
@@ -90,9 +90,10 @@ class MastersController extends Controller {
     $collections = PreservationMasterCollection::all();
     $formats = PreservationMasterFormat::all();
     $departments = PreservationMasterDepartment::all();
+    $max_edit_limit = PreservationMaster::BATCH_EDIT_MAX_LIMIT;
 
     return view('masters.index', 
-        compact('types', 'collections', 'formats', 'departments'));
+        compact('types', 'collections', 'formats', 'departments', 'max_edit_limit'));
   }
 
   /**
@@ -236,7 +237,7 @@ class MastersController extends Controller {
    */
   public function batchEdit(Request $request)
   {
-    $max = 500;
+    $max = PreservationMaster::BATCH_EDIT_MAX_LIMIT;
 
     $masterIds = explode(',', $request->input('ids'));
     // See similar in ItemsController.php for comments on the below

--- a/app/Models/PreservationMaster.php
+++ b/app/Models/PreservationMaster.php
@@ -16,6 +16,8 @@ class PreservationMaster extends Model {
   use SoftDeletes;
   use Markable;
 
+  const BATCH_EDIT_MAX_LIMIT = 1000;
+
   protected $dates = ['deleted_at'];
   
   protected $revisionCreationsEnabled = true;

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -16,6 +16,8 @@ class UsersTableSeeder extends Seeder
         {
           $password = Hash::make(env('ADMIN_USER_PASSWORD'));
           $users[] = [
+            'first_name' => 'Dev',
+            'last_name' => 'Admin',
             'email' => 'admin@jitterbug.com',
             'admin' => 1,
             'username' => 'dev-admin',

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -687,7 +687,8 @@ jitterbug = {
   initMastersBatchMenu: function() {
     $('#masters-batch-edit').click(function(event) {
       var tableSelection = jitterbug.tableSelection;
-      if (!jitterbug.validateBatchSelection(tableSelection, 'editing', 500)) {
+      var max_edit_limit =$(this).data('max-edit-limit');
+      if (!jitterbug.validateBatchSelection(tableSelection, 'editing', max_edit_limit)) {
         return;
       }
       jitterbug.submitBatchEditForm('masters', tableSelection);

--- a/resources/views/masters/index.blade.php
+++ b/resources/views/masters/index.blade.php
@@ -15,7 +15,7 @@
         <div class="btn-group">
           <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-cubes" data-toggle="dropdown" aria-hidden="true"></i> Batch</button>
           <div class="dropdown-menu">
-            <a id="masters-batch-edit" class="dropdown-item" href="#">Edit</a>
+            <a id="masters-batch-edit" class="dropdown-item" href="#" data-max-edit-limit="{{$max_edit_limit}}">Edit</a>
             <a id="masters-batch-export" class="dropdown-item" href="#">Export</a>
             <a id="masters-batch-mark" class="dropdown-item" href="#">Mark</a>
             <a id="masters-batch-unmark" class="dropdown-item" href="#">Unmark</a>


### PR DESCRIPTION
…adding first and last name to dev admin user seeder

Success! A user can get to the batch edit page with more than 500 records selected:
![Screen Shot 2019-03-21 at 8 50 54 AM](https://user-images.githubusercontent.com/6546457/54753378-4a59ac80-4bb7-11e9-810f-c078f0c370b9.png)
![Screen Shot 2019-03-21 at 8 52 07 AM](https://user-images.githubusercontent.com/6546457/54753379-4c237000-4bb7-11e9-8fcf-363afde8988f.png)


Test by: Clicking on preservation masters in jitterbug. Select Audio in the filters, and then proceed to select 500+ records by clicking on the first one, then shift + click on records. As you proceed through the pagination, JB will remember your selections. Then, click on Batch => Edit and it should let you proceed.