### PR TITLE
Appdev 6551 delete multiple marks

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -4844,7 +4844,7 @@ Dashboard
 #dashboard .marks-module .timestamp {
   color: #9a9a9a; }
 
-#dashboard .marks-module .delete {
+#dashboard .marks-module .delete-checkbox {
   margin-right: .5rem;
   float: right;
   color: #d6d6d6;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -4847,7 +4847,8 @@ Dashboard
 #dashboard .marks-module .delete {
   margin-right: .5rem;
   float: right;
-  color: #d6d6d6; }
+  color: #d6d6d6;
+  margin-top:0.5rem;}
 
 #dashboard .marks-module .delete:hover {
   color: #d16642; }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -4853,6 +4853,19 @@ Dashboard
 #dashboard .marks-module .delete:hover {
   color: #d16642; }
 
+#dashboard .marks-module #mark-checkbox-all {
+  float:right;
+  margin-top: 0.5rem;
+  margin-right: 1.9rem;}
+
+#dashboard .marks-module .select-all-label {
+  float: right;
+  padding-right: 2%;}
+
+#dashboard .marks-module .select-all {
+  display: block;
+  width: 100%;}
+
 #dashboard .marks-module .no-marks {
   display: none; }
 
@@ -4864,7 +4877,9 @@ Dashboard
 
 #dashboard .marks {
   height: 331px;
-  overflow-y: scroll; }
+  overflow-y: scroll;
+  display: block;
+  width: 100%}
 
 /* -------------------------------------------
 Filter Panel

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -78,41 +78,37 @@ jitterbug = {
   },
 
   initSelectAll: function() {
-    // listen for click inside the modal
-    $(window).on('shown.bs.modal', function (e) {
-      $('#checkedAll').change(function(event) {
-        // check all boxes if select all is clicked or vice versa
-        if (this.checked) {
-          $(".checkSingle").each(function() {
-            this.checked=true;
-          });
-        } else {
-          $(".checkSingle").each(function() {
-            this.checked=false;
-          });
+    $('#checkedAll').change(function(event) {
+      // check all boxes if select all is clicked or vice versa
+      if (this.checked) {
+        $(".checkSingle").each(function() {
+          this.checked=true;
+        });
+      } else {
+        $(".checkSingle").each(function() {
+          this.checked=false;
+        });
+      }
+    });
+
+    // if all checkboxes are individually clicked, populate select all accordingly
+    $(".checkSingle").click(function () {
+      if ($(this).is(":checked")) {
+        var isAllChecked = 0;
+
+        $(".checkSingle").each(function() {
+          if (!this.checked)
+            isAllChecked = 1;
+        });
+
+        if (isAllChecked == 0) {
+          $("#checkedAll").prop("checked", true);
         }
-      });
-
-      // if all checkboxes are individually clicked, populate select all accordingly
-      $(".checkSingle").click(function () {
-        if ($(this).is(":checked")) {
-          var isAllChecked = 0;
-
-          $(".checkSingle").each(function() {
-            if (!this.checked)
-              isAllChecked = 1;
-          });
-
-          if (isAllChecked == 0) {
-            $("#checkedAll").prop("checked", true);
-          }
-        }
-        else {
-          $("#checkedAll").prop("checked", false);
-        }
-      });
-
-    })
+      }
+      else {
+        $("#checkedAll").prop("checked", false);
+      }
+    });
   },
 
   initAdmin: function() {
@@ -1134,6 +1130,7 @@ jitterbug = {
         }, delay);
         $('#data-export-form input[name="ids"]').val(
           tableSelection.selectedIds());
+        jitterbug.initSelectAll();
       },
       error: function (jqXHR, textStatus, error) {
         console.log('Could not fetch export fields: ' + error);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -77,36 +77,36 @@ jitterbug = {
     });
   },
 
-  initSelectAll: function() {
-    $('#checkedAll').change(function(event) {
+  initSelectAll: function(allSelector, checkboxSelector) {
+    $(allSelector).change(function(event) {
       // check all boxes if select all is clicked or vice versa
       if (this.checked) {
-        $(".checkSingle").each(function() {
+        $(checkboxSelector).each(function() {
           this.checked=true;
         });
       } else {
-        $(".checkSingle").each(function() {
+        $(checkboxSelector).each(function() {
           this.checked=false;
         });
       }
     });
 
     // if all checkboxes are individually clicked, populate select all accordingly
-    $(".checkSingle").click(function () {
+    $(checkboxSelector).change(function () {
       if ($(this).is(":checked")) {
         var isAllChecked = 0;
 
-        $(".checkSingle").each(function() {
+        $(checkboxSelector).each(function() {
           if (!this.checked)
             isAllChecked = 1;
         });
 
         if (isAllChecked == 0) {
-          $("#checkedAll").prop("checked", true);
+          $(allSelector).prop("checked", true);
         }
       }
       else {
-        $("#checkedAll").prop("checked", false);
+        $(allSelector).prop("checked", false);
       }
     });
   },
@@ -1130,7 +1130,7 @@ jitterbug = {
         }, delay);
         $('#data-export-form input[name="ids"]').val(
           tableSelection.selectedIds());
-        jitterbug.initSelectAll();
+        jitterbug.initSelectAll('#checkedAll', ".checkSingle");
       },
       error: function (jqXHR, textStatus, error) {
         console.log('Could not fetch export fields: ' + error);
@@ -2352,7 +2352,6 @@ jitterbug = {
       }
 
       getMarks();
-      toggleAllMarks();
     },
 
     getMarks = function() {
@@ -2368,6 +2367,7 @@ jitterbug = {
         var truncatedUser = selectedUserFullName.length > 13 ? 
           selectedUserFullName.substr(0, 13) + '...' : selectedUserFullName;
         $(selectedUserSelector).text(truncatedUser);
+        jitterbug.initSelectAll('#mark-checkbox-all', '.delete-checkbox:visible');
       });
     },
 
@@ -2380,10 +2380,8 @@ jitterbug = {
       });
 
       // Hook up delete x's if they are present
-      $(marksSelector + ' .delete').click(function(event) {
-        //event.preventDefault();
+      $('.delete-checkbox').click(function(event) {
         event.stopImmediatePropagation();
-        console.log('method activated!');
         // // This will be the mark's li
         // var parent = $(this).parent();
         // var data = {};
@@ -2411,23 +2409,9 @@ jitterbug = {
 
     },
 
-    toggleAllMarks = function() {
-      $('#mark-checkbox-all').change(function() {
-        if (this.checked) {
-          $(marksSelector + ' .delete:visible').each(function (){
-            this.checked=true;
-          })
-        } else {
-          $(marksSelector + ' .delete:visible').each(function() {
-            this.checked=false;
-          })
-        }
-      });
-    },
-
     deselectAllMarks = function() {
       $('#mark-checkbox-all').prop('checked', false);
-      $(marksSelector + ' .delete').each(function() {
+      $('.delete-checkbox').each(function() {
         this.checked=false;
       });
     },

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2380,29 +2380,30 @@ jitterbug = {
 
       // Hook up delete x's if they are present
       $(marksSelector + ' .delete').click(function(event) {
-        event.preventDefault();
+        //event.preventDefault();
         event.stopImmediatePropagation();
-        // This will be the mark's li
-        var parent = $(this).parent();
-        var data = {};
-        var markableType = parent.data('object-type');
-        if (markableType == 'item') {
-          markableType = 'AudioVisualItem';
-        } else if (markableType == 'master') {
-          markableType = 'PreservationMaster';
-        } else if (markableType == 'transfer') {
-          markableType = 'Transfer';
-        }
-        data['markableType'] = markableType;
-        data['markableIds'] = [parent.data('object-id')];
-        data['_method'] = 'DELETE';
-        $.post('/marks', data, function(data) {
-          parent.remove();
-          // Reload the marks part of the DOM so if the user
-          // navigates away from the page, and then uses
-          // the back button, the current state is cached.
-          getMarks();
-        });
+        console.log('method activated!');
+        // // This will be the mark's li
+        // var parent = $(this).parent();
+        // var data = {};
+        // var markableType = parent.data('object-type');
+        // if (markableType == 'item') {
+        //   markableType = 'AudioVisualItem';
+        // } else if (markableType == 'master') {
+        //   markableType = 'PreservationMaster';
+        // } else if (markableType == 'transfer') {
+        //   markableType = 'Transfer';
+        // }
+        // data['markableType'] = markableType;
+        // data['markableIds'] = [parent.data('object-id')];
+        // data['_method'] = 'DELETE';
+        // $.post('/marks', data, function(data) {
+        //   parent.remove();
+        //   // Reload the marks part of the DOM so if the user
+        //   // navigates away from the page, and then uses
+        //   // the back button, the current state is cached.
+        //   getMarks();
+        // });
 
       });
     },

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2371,6 +2371,50 @@ jitterbug = {
       });
     },
 
+    deleteMarks = function() {
+      var marksToDelete = {};
+
+      // gather and sort all selected markable IDs by type
+      $('input.delete-checkbox:checkbox:checked').each(function() {
+        var parent = $(this).parent();
+        var markId = parent.data('object-id');
+        var type = parent.data('object-type');
+
+        if (marksToDelete[type] === undefined) {
+          marksToDelete[type] = [markId];
+        } else {
+          marksToDelete[type].push(markId);
+        }
+      });
+
+      var keys = Object.keys(marksToDelete);
+
+      for (var index in keys) {
+        key = keys[index];
+
+        // reformat names correctly
+        if (key == 'item') {
+          var markableType = 'AudioVisualItem';
+        } else if (key == 'master') {
+          var markableType = 'PreservationMaster';
+        } else if (key == 'transfer') {
+          var markableType = 'Transfer';
+        }
+
+        var data = {};
+        data['markableType'] = markableType;
+        data['markableIds'] = marksToDelete[key];
+        data['_method'] = 'DELETE';
+
+        $.post('/marks', data, function(data) {
+          // Reload the marks part of the DOM so if the user
+          // navigates away from the page, and then uses
+          // the back button, the current state is cached.
+          getMarks();
+        });
+      }
+    },
+
     link = function() {
       // Hook up individual marks to their associated objects
       $(marksSelector).click(function(event) {
@@ -2379,34 +2423,15 @@ jitterbug = {
         window.location.href='/' + type + 's/' + id;
       });
 
-      // Hook up delete x's if they are present
+      // unlink delete checkboxes from the associated objects
       $('.delete-checkbox').click(function(event) {
         event.stopImmediatePropagation();
-        // // This will be the mark's li
-        // var parent = $(this).parent();
-        // var data = {};
-        // var markableType = parent.data('object-type');
-        // if (markableType == 'item') {
-        //   markableType = 'AudioVisualItem';
-        // } else if (markableType == 'master') {
-        //   markableType = 'PreservationMaster';
-        // } else if (markableType == 'transfer') {
-        //   markableType = 'Transfer';
-        // }
-        // data['markableType'] = markableType;
-        // data['markableIds'] = [parent.data('object-id')];
-        // data['_method'] = 'DELETE';
-        // $.post('/marks', data, function(data) {
-        //   parent.remove();
-        //   // Reload the marks part of the DOM so if the user
-        //   // navigates away from the page, and then uses
-        //   // the back button, the current state is cached.
-        //   getMarks();
-        // });
-
       });
-      toggleSelectAllVisibility()
 
+      // hook up delete marks button
+      $('.delete-marks button').click(function() {
+        deleteMarks();
+      });
     },
 
     deselectAllMarks = function() {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2326,6 +2326,8 @@ jitterbug = {
       $(filtersSelector).click(function(event) {
         event.preventDefault();
         currentFilter = $(this).data('filter');
+        // when the filter changes, deselect all marks
+        deselectAllMarks();
         store();
         render();
       });
@@ -2353,6 +2355,7 @@ jitterbug = {
       }
 
       getMarks();
+      toggleAllMarks();
     },
 
     getMarks = function() {
@@ -2405,6 +2408,29 @@ jitterbug = {
         //   getMarks();
         // });
 
+      });
+
+
+    },
+
+    toggleAllMarks = function() {
+      $('#mark-checkbox-all').change(function() {
+        if (this.checked) {
+          $(marksSelector + ' .delete:visible').each(function (){
+            this.checked=true;
+          })
+        } else {
+          $(marksSelector + ' .delete:visible').each(function() {
+            this.checked=false;
+          })
+        }
+      });
+    },
+
+    deselectAllMarks = function() {
+      $('#mark-checkbox-all').prop('checked', false);
+      $(marksSelector + ' .delete').each(function() {
+        this.checked=false;
       });
     },
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2365,6 +2365,7 @@ jitterbug = {
       $.get('/dashboard/marks-for-user', query, function(data) {
         $(marksContainer).replaceWith(data);
         link();
+        toggleSelectAllVisibility(selectedUserId);
         render();
         var selectedUserFullName = selectedUserName();
         var truncatedUser = selectedUserFullName.length > 13 ? 
@@ -2409,7 +2410,7 @@ jitterbug = {
         // });
 
       });
-
+      toggleSelectAllVisibility()
 
     },
 
@@ -2432,6 +2433,16 @@ jitterbug = {
       $(marksSelector + ' .delete').each(function() {
         this.checked=false;
       });
+    },
+
+    toggleSelectAllVisibility = function(selectedUserId) {
+      if (selectedUserId === currentUser().id) {
+        $('.select-all'). show();
+        $('.delete-marks').show();
+      } else {
+        $('.select-all').hide();
+        $('.delete-marks').hide();
+      }
     },
 
     render = function() {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2350,6 +2350,13 @@ jitterbug = {
           }
         });
       }
+      // set up delete marks button
+      $('.delete-marks button').click(function() {
+        var size = $('input.delete-checkbox:checkbox:checked').length;
+        if (confirm('Are you sure you want to delete ' + size + ' marks?')) {
+          deleteMarks();
+        }
+      });
 
       getMarks();
     },
@@ -2426,11 +2433,6 @@ jitterbug = {
       // unlink delete checkboxes from the associated objects
       $('.delete-checkbox').click(function(event) {
         event.stopImmediatePropagation();
-      });
-
-      // hook up delete marks button
-      $('.delete-marks button').click(function() {
-        deleteMarks();
       });
     },
 

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -54,7 +54,6 @@ JITTERBUG = {
       jitterbug.initItemsNewButton();
       jitterbug.initItemsBatchMenu();
       jitterbug.initBatchDeleteForm();
-      jitterbug.initSelectAll();
     },
 
     show: function() {
@@ -101,7 +100,6 @@ JITTERBUG = {
       jitterbug.initMastersNewButton();
       jitterbug.initMastersBatchMenu();
       jitterbug.initBatchDeleteForm();
-      jitterbug.initSelectAll();
     },
 
     show: function() {
@@ -161,7 +159,6 @@ JITTERBUG = {
       jitterbug.initTransfersNewButton();
       jitterbug.initTransfersBatchMenu();
       jitterbug.initBatchDeleteForm();
-      jitterbug.initSelectAll();
     },
 
     show: function() {

--- a/resources/views/dashboard/_marks.blade.php
+++ b/resources/views/dashboard/_marks.blade.php
@@ -5,7 +5,7 @@
                 <li role="button" data-object-id="{{$mark->objectId()}}" data-object-type="{{$mark->objectType()}}">
                   {{$mark->object()}} - <span class="timestamp">{{$mark->timestamp()}}</span>
                   @if ($currentUser->id === $selectedMarksUserId)
-                    <input class="form-check-input delete" type="checkbox" value="" id="mark-checkbox-{{$mark->objectId()}}" title="choose mark to delete">
+                    <input class="delete-checkbox" type="checkbox" value="" title="choose mark to delete">
                     {{--<a href="#" role="button" class="delete" title="Delete mark"><i class="fa fa-times" aria-hidden="true"></i></a>--}}
                   @endif
                 </li>

--- a/resources/views/dashboard/_marks.blade.php
+++ b/resources/views/dashboard/_marks.blade.php
@@ -2,7 +2,13 @@
             <ol>
               <li class="no-marks"></li>
               @foreach ($marks as $mark)
-              <li role="button" data-object-id="{{$mark->objectId()}}" data-object-type="{{$mark->objectType()}}">{{$mark->object()}} - <span class="timestamp">{{$mark->timestamp()}}</span>@if ($currentUser->id === $selectedMarksUserId)<a href="#" role="button" class="delete" title="Delete mark"><i class="fa fa-times" aria-hidden="true"></i></a>@endif</li>
+                <li role="button" data-object-id="{{$mark->objectId()}}" data-object-type="{{$mark->objectType()}}">
+                  {{$mark->object()}} - <span class="timestamp">{{$mark->timestamp()}}</span>
+                  @if ($currentUser->id === $selectedMarksUserId)
+                    <input class="form-check-input delete" type="checkbox" value="" id="mark-checkbox-{{$mark->objectId()}}" title="choose mark to delete">
+                    {{--<a href="#" role="button" class="delete" title="Delete mark"><i class="fa fa-times" aria-hidden="true"></i></a>--}}
+                  @endif
+                </li>
               @endforeach
             </ol>
           </div>

--- a/resources/views/dashboard/_marks.blade.php
+++ b/resources/views/dashboard/_marks.blade.php
@@ -6,7 +6,6 @@
                   {{$mark->object()}} - <span class="timestamp">{{$mark->timestamp()}}</span>
                   @if ($currentUser->id === $selectedMarksUserId)
                     <input class="delete-checkbox" type="checkbox" value="" title="choose mark to delete">
-                    {{--<a href="#" role="button" class="delete" title="Delete mark"><i class="fa fa-times" aria-hidden="true"></i></a>--}}
                   @endif
                 </li>
               @endforeach

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -93,6 +93,11 @@
               </div>
             </div>
           </div>
+
+          <div class="select-all">
+            <input class="form-check-input" type="checkbox" value="" id="mark-checkbox-all" title="Select all marks">
+            <label class="select-all-label">Select All</label>
+          </div>
       
           <div class="marks">
             <ol>
@@ -100,6 +105,9 @@
             </ol>
           </div>
 
+          <div>
+            <button class="btn btn-secondary" title="Delete selected marks"><i class="fa fa-trash" aria-hidden="true"></i></button>
+          </div>
         </div>
       </div>
     </div>

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -105,7 +105,7 @@
             </ol>
           </div>
 
-          <div>
+          <div class="delete-marks">
             <button class="btn btn-secondary" title="Delete selected marks"><i class="fa fa-trash" aria-hidden="true"></i></button>
           </div>
         </div>


### PR DESCRIPTION
This PR contains functionality for deleting multiple marks at a time from the Jitterbug dashboard. A user may select all, or a few marks at a time via checkbox. The checkboxes and delete button will only show up if the current user is the same as the user of the listed marks. There is a confirmation with the number of marks to delete.

I cleaned up the `initSelectAll` function used for selecting all fields to export and made it reusable. In doing so, I fixed a bug in which the select all functionality would not work if the server is too slow.


![Screen Shot 2019-03-27 at 9 26 24 AM](https://user-images.githubusercontent.com/6546457/55079814-53dd8b80-5073-11e9-9d30-97b407590c72.png)

