### PR TITLE
APPDEV-8722 archival identifier form and column in collections admin index

### DIFF
--- a/app/Http/Requests/CollectionRequest.php
+++ b/app/Http/Requests/CollectionRequest.php
@@ -35,6 +35,8 @@ class CollectionRequest extends Request {
          $this->route()->parameter('collections'),
       'name' => $required . 'min:3|max:255|unique:collections,name,' .
          $this->route()->parameter('collections'),
+      'archivalIdentifier' => $required . 'min:3|max:255|unique:collections,archival_identifier,' .
+        $this->route()->parameter('collections'),
       //TODO APPDEV-8640
       //'collectionTypeId' => $required.'integer',
     ];
@@ -52,6 +54,10 @@ class CollectionRequest extends Request {
       'name.unique' => 'The collection name has already been used.',
       'name.min' => 'The collection name must be at least :min characters.',
       'name.max' => 'The collection name must be less than :max characters.',
+      'archivalIdentifier.required' => 'A collection archival identifier is required.',
+      'archivalIdentifier.unique' => 'The collection archival identifier has already been used.',
+      'archivalIdentifier.min' => 'The collection archival identifier must be at least :min characters.',
+      'archivalIdentifier.max' => 'The collection archival identifier must be less than :max characters.',
       //TODO APPDEV-8640
       //'collectionTypeId.required' => 'A collection type ID is required.',
       //'collectionTypeId.integer' => 'The collection type ID must be an integer.',

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -10,7 +10,7 @@ class Collection extends Model {
 
   protected $dates = array('deleted_at');
 
-  protected $fillable = array('id', 'name', 'collectionTypeId');
+  protected $fillable = array('id', 'name', 'collectionTypeId', 'archivalIdentifier');
 
   public $incrementing = false;
 

--- a/resources/views/admin/_collections.blade.php
+++ b/resources/views/admin/_collections.blade.php
@@ -8,8 +8,9 @@
           <thead>
             <tr>
               <th width="8%">ID</th>
-              <th width="57%">Name</th>
-              <th width="30%">Collection Type</th>
+              <th width="47%">Name</th>
+              <th width="20%">Collection Type</th>
+              <th width="20%">Archival Identifier</th>
               <th width="5%"></th>
             </tr>
           </thead>
@@ -23,6 +24,7 @@
                   {{ \Jitterbug\Models\CollectionType::formattedName($record->collectionType) }}
                 </span>
               </td>
+              <td><span class="editable" data-id="{{ $record->id }}" data-field="archivalIdentifier" role="button">{{ $record->archivalIdentifier }}</span></td>
               <td><a href="#" role="button" class="delete" title="Delete record" style="float: right;"><i class="fa fa-times" aria-hidden="true"></i></a></td>
             </tr>
             @endforeach
@@ -36,6 +38,7 @@
       <form class="form-inline">
         <input type="text" name="id" class="form-control form-control-sm" maxlength="8" placeholder="Id" autocomplete="off" style="width: 65px;">
         <input type="text" name="name" class="form-control form-control-sm" maxlength="255" placeholder="Name" autocomplete="off" style="width: 250px;">
+        <input type="text" name="archivalIdentifier" class="form-control form-control-sm" maxlength="255" placeholder="Archival Identifier" autocomplete="off" style="width: 250px;">
 {{--   TODO APPDEV-8640     {!! Form::select('collectionTypeId', $collectionTypes, null, array('class' => 'form-control form-control-sm')) !!}--}}
         <button class="btn btn-sm btn-secondary popover-submit" type="submit"><i class="fa fa-fw fa-check" aria-hidden="true"></i></button>
         <button class="btn btn-sm btn-secondary cancel-new-record"><i class="fa fa-fw fa-ban" aria-hidden="true"></i></button>
@@ -53,6 +56,14 @@
     <div id="edit-name-form" class="hidden">
       <form class="form-inline">
         <input type="text" name="name" class="form-control form-control-sm" maxlength="255" placeholder="Name" autocomplete="off" style="width: 250px;">
+        <button class="btn btn-sm btn-secondary popover-submit" type="submit"><i class="fa fa-fw fa-check" aria-hidden="true"></i></button>
+        <button class="btn btn-sm btn-secondary cancel-edit"><i class="fa fa-fw fa-ban" aria-hidden="true"></i></button>
+      </form>
+    </div>
+
+    <div id="edit-archivalIdentifier-form" class="hidden">
+      <form class="form-inline">
+        <input type="text" name="archivalIdentifier" class="form-control form-control-sm" maxlength="255" placeholder="Archival Identifier" autocomplete="off" style="width: 250px;">
         <button class="btn btn-sm btn-secondary popover-submit" type="submit"><i class="fa fa-fw fa-check" aria-hidden="true"></i></button>
         <button class="btn btn-sm btn-secondary cancel-edit"><i class="fa fa-fw fa-ban" aria-hidden="true"></i></button>
       </form>


### PR DESCRIPTION
This PR makes it possible to see the archival identifer on collections and edit it. You can now also add the archival identifier when making a new collection.

![Screen Shot 2019-06-12 at 3 43 54 PM](https://user-images.githubusercontent.com/6546457/59381812-5ffbef80-8d2a-11e9-89e9-0288179b71c7.png)

![Screen Shot 2019-06-12 at 3 44 01 PM](https://user-images.githubusercontent.com/6546457/59381830-68ecc100-8d2a-11e9-953e-9d020e1a5b56.png)
