### PR TITLE
Appdev 8733 new column for new call number sequences

### DIFF
--- a/database/migrations/2019_07_22_180603_add_archival_identifier_to_new_call_number_sequences.php
+++ b/database/migrations/2019_07_22_180603_add_archival_identifier_to_new_call_number_sequences.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddArchivalIdentifierToNewCallNumberSequences extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+      Schema::table('new_call_number_sequences', function (Blueprint $table) {
+        $table->string('archival_identifier')->after('collection_id')->unique()->nullable();
+      });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+      Schema::table('new_call_number_sequences', function (Blueprint $table) {
+        $table->dropColumn('archival_identifier');
+      });
+    }
+}

--- a/database/migrations/2019_07_22_180603_add_archival_identifier_to_new_call_number_sequences.php
+++ b/database/migrations/2019_07_22_180603_add_archival_identifier_to_new_call_number_sequences.php
@@ -14,7 +14,7 @@ class AddArchivalIdentifierToNewCallNumberSequences extends Migration
     public function up()
     {
       Schema::table('new_call_number_sequences', function (Blueprint $table) {
-        $table->string('archival_identifier')->after('collection_id')->unique()->nullable();
+        $table->string('archival_identifier')->after('collection_id')->nullable();
       });
     }
 

--- a/database/seeds/AddArchivalIdentifierSeederToCollections.php
+++ b/database/seeds/AddArchivalIdentifierSeederToCollections.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Seeder;
 use Jitterbug\Models\Collection;
 
-class AddArchivalIdentifierSeeder extends Seeder
+class AddArchivalIdentifierSeederToCollections extends Seeder
 {
     /**
      * Run the database seeds.

--- a/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Jitterbug\Models\NewCallNumberSequence;
+
+class AddArchivalIdentifierToCallNumbersSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+      $callNumberSequences = NewCallNumberSequence::all();
+
+      foreach ($callNumberSequences as $callNumberSequence) {
+        $callNumberSequence->archivalIdentifier = (string) $callNumberSequence->collectionId;
+        $callNumberSequence->save();
+      }
+    }
+}

--- a/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use Jitterbug\Models\NewCallNumberSequence;
 
 class AddArchivalIdentifierToCallNumbersSeeder extends Seeder
 {
@@ -12,7 +11,8 @@ class AddArchivalIdentifierToCallNumbersSeeder extends Seeder
      */
     public function run()
     {
-      $callNumberSequences = NewCallNumberSequence::all();
+      // find all the new call number sequences that need their archival_identifier field populated
+      $callNumberSequences = DB::table('new_call_number_sequences')->whereNull('archival_identifier')->get();
 
       foreach ($callNumberSequences as $callNumberSequence) {
         $callNumberSequence->archivalIdentifier = (string) $callNumberSequence->collectionId;

--- a/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
@@ -11,10 +11,12 @@ class AddArchivalIdentifierToCallNumbersSeeder extends Seeder
      */
     public function run()
     {
+
       // find all the new call number sequences that need their archival_identifier field populated
       $callNumberSequences = DB::table('new_call_number_sequences')->whereNull('archival_identifier')->get();
 
       foreach ($callNumberSequences as $callNumberSequence) {
+        // TODO APPDEV-8779 rework seeder to grab archival identifier from collection record
         $callNumberSequence->archivalIdentifier = (string) $callNumberSequence->collectionId;
         $callNumberSequence->save();
       }

--- a/database/seeds/AddArchivalIdentifierToCollectionsSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCollectionsSeeder.php
@@ -1,9 +1,8 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use Jitterbug\Models\Collection;
 
-class AddArchivalIdentifierSeederToCollections extends Seeder
+class AddArchivalIdentifierToCollectionsSeeder extends Seeder
 {
     /**
      * Run the database seeds.
@@ -13,7 +12,7 @@ class AddArchivalIdentifierSeederToCollections extends Seeder
     public function run()
     {
       // to backfill the collection IDs as strings in the archival_identifier column
-      $collections = Collection::all();
+      $collections = DB::table('collections')->whereNull('archival_identifier')->get();
 
       foreach ($collections as $collection) {
         $collection->archivalIdentifier = (string) $collection->id;

--- a/database/seeds/AddArchivalIdentifierToCollectionsSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCollectionsSeeder.php
@@ -15,6 +15,7 @@ class AddArchivalIdentifierToCollectionsSeeder extends Seeder
       $collections = DB::table('collections')->whereNull('archival_identifier')->get();
 
       foreach ($collections as $collection) {
+        // TODO APPDEV-8779 delete seeder when collection ID is auto incrementing
         $collection->archivalIdentifier = (string) $collection->id;
         $collection->save();
       }


### PR DESCRIPTION
This PR includes the migration for the new archival_identifier column in new call number sequences. There is also a seeder for this column. I also reworked the old archival identifier seeder for collections so that it can be re-run without affecting records that have already been filled in.

I also removed the references to the models in the seeder because i read that it was best practice to not do that.