### PR TITLE
APPDEV-8733 removing references to classes in the archival identifier…

### DIFF
--- a/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
@@ -11,14 +11,11 @@ class AddArchivalIdentifierToCallNumbersSeeder extends Seeder
      */
     public function run()
     {
-
       // find all the new call number sequences that need their archival_identifier field populated
-      $callNumberSequences = DB::table('new_call_number_sequences')->whereNull('archival_identifier')->get();
-
-      foreach ($callNumberSequences as $callNumberSequence) {
-        // TODO APPDEV-8779 rework seeder to grab archival identifier from collection record
-        $callNumberSequence->archivalIdentifier = (string) $callNumberSequence->collectionId;
-        $callNumberSequence->save();
-      }
+      // TODO APPDEV-8779 rework seeder to grab archival identifier from collection record
+      DB::table('new_call_number_sequences')->whereNull('archival_identifier')
+                                            ->update([
+                                              'archival_identifier' => DB::raw('`collection_id`')
+                                            ]);
     }
 }

--- a/database/seeds/AddArchivalIdentifierToCollectionsSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCollectionsSeeder.php
@@ -12,12 +12,11 @@ class AddArchivalIdentifierToCollectionsSeeder extends Seeder
     public function run()
     {
       // to backfill the collection IDs as strings in the archival_identifier column
-      $collections = DB::table('collections')->whereNull('archival_identifier')->get();
-
-      foreach ($collections as $collection) {
-        // TODO APPDEV-8779 delete seeder when collection ID is auto incrementing
-        $collection->archivalIdentifier = (string) $collection->id;
-        $collection->save();
-      }
+      // TODO APPDEV-8779 delete seeder when collection ID is auto incrementing
+      DB::table('collections')->whereNull('archival_identifier')
+                              ->whereNull('deleted_at')
+                              ->update([
+                                'archival_identifier' => DB::raw('`id`')
+                              ]);
     }
 }


### PR DESCRIPTION
… seeders and using the right syntax

This PR uses the `update` syntax to add the right values to the `archival_identifier` column on `collections` and `new_call_number_sequences`.