### PR TITLE
Appdev 8779 auto incrementing collection ids

### DIFF
--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -1,5 +1,5 @@
 ip: 192.168.10.10
-memory: 2048
+memory: 2560
 cpus: 1
 provider: virtualbox
 version: 6.4.0

--- a/app/Http/Controllers/Admin/CollectionsController.php
+++ b/app/Http/Controllers/Admin/CollectionsController.php
@@ -83,11 +83,6 @@ class CollectionsController extends Controller
     if ($request->ajax()) {
       $input = $request->all();
 
-      // If $input['id'] isn't set, the user is editing the name form
-      if (!isset($input['id'])) {
-        $input['id'] = $id;
-      }
-
       $collection = Collection::findOrFail($id);
       $collection->fill($input);
 

--- a/app/Http/Controllers/Admin/CollectionsController.php
+++ b/app/Http/Controllers/Admin/CollectionsController.php
@@ -92,15 +92,6 @@ class CollectionsController extends Controller
         // Update MySQL
         DB::transaction(function () 
           use ($id, $collection, &$affectedItems) {
-          # TODO APPDEV-8779 remove ability to change the ID
-          if($collection->isDirty('id')) {
-            // Mass update rather than item by item, otherwise
-            // revision tracking will kick in.
-            AudioVisualItem::where('collection_id', $id)
-              ->update(['collection_id' => $collection->id]);
-            NewCallNumberSequence::where('collection_id', $id)
-              ->update(['collection_id' => $collection->id]);
-          }
 
           if ($collection->isDirty('archival_identifier')) {
             NewCallNumberSequence::where('collection_id', $id)

--- a/app/Http/Requests/CollectionRequest.php
+++ b/app/Http/Requests/CollectionRequest.php
@@ -31,8 +31,6 @@ class CollectionRequest extends Request {
       $required = 'required|';
     }
     return [
-      'id' => $required . 'integer|unique:collections,id,' . 
-         $this->route()->parameter('collections'),
       'name' => $required . 'min:3|max:255|unique:collections,name,' .
          $this->route()->parameter('collections'),
       'collectionTypeId' => $required.'integer',

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -34,7 +34,8 @@ class Collection extends Model {
 
   public static function autoIncrementIdsScript()
   {
-    $collections = self::all();
+    //$collections = self::all();
+    $collections = Collection::whereIn('id', [100, 200])->get();
     $idTrack = 1;
     $collectionIdMapping = [];
 
@@ -52,21 +53,26 @@ class Collection extends Model {
 
   public static function updateCollectionIdInAudioVisualItems($collectionIdMapping)
   {
-    $avItems = AudioVisualItem::all();
+    //$avItems = AudioVisualItem::all();
+    $avItems = AudioVisualItem::whereIn('id', [1,2,3]);
     $brokenAvItemIds = [];
 
     foreach ($avItems as $avItem) {
       $oldCollectionId = $avItem->collection_id;
+      if ($oldCollectionId === null) {
+        $brokenAvItemIds[] = $avItem->id;
+        continue;
+      }
 
       $avItem->collection_id = $collectionIdMapping[$oldCollectionId];
       if ($avItem->collection_id === null) {
         $brokenAvItemIds[] = $avItem->id;
         continue;
       }
-      $avItem->save();
 
-      return $brokenAvItemIds;
+      $avItem->save();
     }
+    return $brokenAvItemIds;
   }
 
   public static function updateCollectionIdInNewCallNumberSequences($collectionIdMapping)
@@ -82,9 +88,9 @@ class Collection extends Model {
         $brokenSequenceIds[] = $sequence->id;
         continue;
       }
-      $sequence->save();
 
-      return $brokenSequenceIds;
+      $sequence->save();
     }
+    return $brokenSequenceIds;
   }
 }

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -31,4 +31,60 @@ class Collection extends Model {
   {
     return $this->name;
   }
+
+  public static function autoIncrementIdsScript()
+  {
+    $collections = self::all();
+    $idTrack = 1;
+    $collectionIdMapping = [];
+
+    foreach ($collections as $collection) {
+      $oldId = $collection->id;
+      $collection->id = $idTrack;
+      $collection->save();
+
+      $collectionIdMapping[$oldId] = $idTrack;
+
+      $idTrack++;
+    }
+    return $collectionIdMapping;
+  }
+
+  public static function updateCollectionIdInAudioVisualItems($collectionIdMapping)
+  {
+    $avItems = AudioVisualItem::all();
+    $brokenAvItemIds = [];
+
+    foreach ($avItems as $avItem) {
+      $oldCollectionId = $avItem->collection_id;
+
+      $avItem->collection_id = $collectionIdMapping[$oldCollectionId];
+      if ($avItem->collection_id === null) {
+        $brokenAvItemIds[] = $avItem->id;
+        continue;
+      }
+      $avItem->save();
+
+      return $brokenAvItemIds;
+    }
+  }
+
+  public static function updateCollectionIdInNewCallNumberSequences($collectionIdMapping)
+  {
+    $sequences = NewCallNumberSequence::all();
+    $brokenSequenceIds = [];
+
+    foreach($sequences as $sequence) {
+      $oldCollectionId = $sequence->collection_id;
+
+      $sequence->collection_id = $collectionIdMapping[$oldCollectionId];
+      if ($sequence->collection_id === null) {
+        $brokenSequenceIds[] = $sequence->id;
+        continue;
+      }
+      $sequence->save();
+
+      return $brokenSequenceIds;
+    }
+  }
 }

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -63,8 +63,9 @@ class Collection extends Model {
            continue;
          }
 
-         $newCollectionId = $collectionIdMapping[$result->collection_id];
-         if ($newCollection_id === null) {
+         if (isset($collectionIdMapping[$result->collection_id])) {
+           $newCollectionId = $collectionIdMapping[$result->collection_id];
+         } else {
            $brokenIds[] = $result->id;
            continue;
          }

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -56,13 +56,10 @@ class Collection extends Model {
   public static function updateCollectionIdInTable($tableName, $collectionIdMapping)
   {
     $brokenIds = array();
-    DB::table($tableName)->chunkById(1000, function ($results) use (&$brokenIds, &$collectionIdMapping, $tableName) {
+    DB::table($tableName)
+      ->whereNotNull('collection_id')
+      ->chunkById(1000, function ($results) use (&$brokenIds, &$collectionIdMapping, $tableName) {
        foreach ($results as $result) {
-         if ($result->collection_id === null) {
-           $brokenIds[] = $result->id;
-           continue;
-         }
-
          if (isset($collectionIdMapping[$result->collection_id])) {
            $newCollectionId = $collectionIdMapping[$result->collection_id];
          } else {
@@ -74,7 +71,7 @@ class Collection extends Model {
            ->where('id', $result->id)
            ->update(['collection_id' => $newCollectionId]);
        }
-     });
+    });
 
     return $brokenIds;
   }

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
 		"ramsey/uuid": "^3.5",
 		"adldap2/adldap2-laravel": "2.1.*",
 		"jimmiw/php-time-ago": "^0.4.14",
-		"laravel/tinker": "^1.0"
+		"laravel/tinker": "^1.0",
+		"doctrine/dbal": "^2.5"
 	},
 	"require-dev": {
         "fzaninotto/faker": "~1.4",
-		"mockery/mockery": "~0.9",
+		"mockery/mockery": "1.2.2",
 		"phpunit/phpunit": "~5.7",
 		"symfony/css-selector": "~3.1",
 		"symfony/dom-crawler": "~3.1",

--- a/database/migrations/2019_08_23_194815_change_collection_id_column_to_autoincrement.php
+++ b/database/migrations/2019_08_23_194815_change_collection_id_column_to_autoincrement.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeCollectionIdColumnToAutoincrement extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('collections', function (Blueprint $table) {
+          $table->increments('id')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('collections', function (Blueprint $table) {
+          $table->integer('id')->change();
+        });
+    }
+}

--- a/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
@@ -12,10 +12,12 @@ class AddArchivalIdentifierToCallNumbersSeeder extends Seeder
     public function run()
     {
       // find all the new call number sequences that need their archival_identifier field populated
-      // TODO APPDEV-8779 rework seeder to grab archival identifier from collection record
-      DB::table('new_call_number_sequences')->whereNull('archival_identifier')
-                                            ->update([
-                                              'archival_identifier' => DB::raw('`collection_id`')
-                                            ]);
+      // fill it in with the corresponding archival identifier from the associated collection
+      DB::table('new_call_number_sequences as sequence')
+        ->whereNull('sequence.archival_identifier')
+        ->join('collections as collection', 'sequence.collection_id', '=', 'collection.id')
+        ->update([
+          'sequence.archival_identifier' => DB::raw('`collection`.`archival_identifier`')
+        ]);
     }
 }

--- a/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCallNumbersSeeder.php
@@ -11,14 +11,11 @@ class AddArchivalIdentifierToCallNumbersSeeder extends Seeder
      */
     public function run()
     {
-
       // find all the new call number sequences that need their archival_identifier field populated
-      $callNumberSequences = DB::table('new_call_number_sequences')->whereNull('archival_identifier')->get();
-
-      foreach ($callNumberSequences as $callNumberSequence) {
-        // TODO APPDEV-8779 rework seeder to grab archival identifier from collection record
-        $callNumberSequence->archivalIdentifier = (string) $callNumberSequence->collectionId;
-        $callNumberSequence->save();
-      }
+      // TODO APPDEV-8779 rework seeder to grab archival identifier from collection record
+      DB::table('new_call_number_sequences')->whereNull('archival_identifier')
+                                            ->update([
+                                              'archival_identifier' => DB::raw('`collection_id`')
+                                            ]);
     }
 }

--- a/database/seeds/AddArchivalIdentifierToCollectionsSeeder.php
+++ b/database/seeds/AddArchivalIdentifierToCollectionsSeeder.php
@@ -12,12 +12,11 @@ class AddArchivalIdentifierToCollectionsSeeder extends Seeder
     public function run()
     {
       // to backfill the collection IDs as strings in the archival_identifier column
-      $collections = DB::table('collections')->whereNull('archival_identifier')->get();
-
-      foreach ($collections as $collection) {
-        // TODO APPDEV-8779 delete seeder when collection ID is auto incrementing
-        $collection->archivalIdentifier = (string) $collection->id;
-        $collection->save();
-      }
+      // TODO APPDEV-8779 delete seeder when collection ID is auto incrementing
+      DB::table('collections')->whereNull('archival_identifier')
+                              ->whereNull('deleted_at')
+                              ->update([
+                                'archival_identifier' => DB::raw('`id`')
+                              ]);
     }
 }

--- a/resources/views/admin/_collections.blade.php
+++ b/resources/views/admin/_collections.blade.php
@@ -7,24 +7,22 @@
         <table style="margin-top: .5rem;" class="table table-sm table-hover">
           <thead>
             <tr>
-              <th width="8%">ID</th>
-              <th width="47%">Name</th>
+              <th width="24%">Archival Identifier</th>
+              <th width="51%">Name</th>
               <th width="20%">Collection Type</th>
-              <th width="20%">Archival Identifier</th>
               <th width="5%"></th>
             </tr>
           </thead>
           <tbody>
             @foreach ($records as $record)
             <tr>
-              <td><span data-id="{{ $record->id }}" data-field="id">{{ $record->id }}</span></td>
+              <td><span class="editable" data-id="{{ $record->id }}" data-field="archivalIdentifier" role="button">{{ $record->archivalIdentifier }}</span></td>
               <td><span class="editable" data-id="{{ $record->id }}" data-field="name" role="button">{{ $record->name }}</span></td>
               <td>
                 <span class="editable" data-id="{{ $record->id }}" data-field="collectionTypeId" role="button">
                   {{ \Jitterbug\Models\CollectionType::formattedName($record->collectionType) }}
                 </span>
               </td>
-              <td><span class="editable" data-id="{{ $record->id }}" data-field="archivalIdentifier" role="button">{{ $record->archivalIdentifier }}</span></td>
               <td><a href="#" role="button" class="delete" title="Delete record" style="float: right;"><i class="fa fa-times" aria-hidden="true"></i></a></td>
             </tr>
             @endforeach

--- a/resources/views/admin/_collections.blade.php
+++ b/resources/views/admin/_collections.blade.php
@@ -17,10 +17,10 @@
           <tbody>
             @foreach ($records as $record)
             <tr>
-              <td><span class="editable" data-id="{{ $record->id }}" data-field="id" role="button">{{ $record->id }}</span></td>
+              <td><span data-id="{{ $record->id }}" data-field="id">{{ $record->id }}</span></td>
               <td><span class="editable" data-id="{{ $record->id }}" data-field="name" role="button">{{ $record->name }}</span></td>
               <td>
-                <span class="editable" data-id="{{ $record->id }}" data-field="collectionTypeId" data-role="button">
+                <span class="editable" data-id="{{ $record->id }}" data-field="collectionTypeId" role="button">
                   {{ \Jitterbug\Models\CollectionType::formattedName($record->collectionType) }}
                 </span>
               </td>
@@ -42,14 +42,6 @@
         <input type="text" name="archivalIdentifier" class="form-control form-control-sm" maxlength="255" placeholder="Archival Identifier" autocomplete="off" style="width: 250px;">
         <button class="btn btn-sm btn-secondary popover-submit" type="submit"><i class="fa fa-fw fa-check" aria-hidden="true"></i></button>
         <button class="btn btn-sm btn-secondary cancel-new-record"><i class="fa fa-fw fa-ban" aria-hidden="true"></i></button>
-      </form>
-    </div>
-
-    <div id="edit-id-form" class="hidden">
-      <form class="form-inline">
-        <input type="text" name="id" class="form-control form-control-sm" maxlength="8" placeholder="Id" autocomplete="off" style="width: 65px;">
-        <button class="btn btn-sm btn-secondary popover-submit" type="submit"><i class="fa fa-fw fa-check" aria-hidden="true"></i></button>
-        <button class="btn btn-sm btn-secondary cancel-edit"><i class="fa fa-fw fa-ban" aria-hidden="true"></i></button>
       </form>
     </div>
 

--- a/resources/views/admin/_collections.blade.php
+++ b/resources/views/admin/_collections.blade.php
@@ -36,7 +36,6 @@
     {{--Need the surrounding div here to keep the form displaying inline--}}
     <div id="new-record-form" class="hidden">
       <form class="form-inline">
-        <input type="text" name="id" class="form-control form-control-sm" maxlength="8" placeholder="Id" autocomplete="off" style="width: 65px;">
         <input type="text" name="name" class="form-control form-control-sm" maxlength="255" placeholder="Name" autocomplete="off" style="width: 250px;">
         {!! Form::select('collectionTypeId', $collectionTypes, null, array('class' => 'form-control form-control-sm')) !!}
         <input type="text" name="archivalIdentifier" class="form-control form-control-sm" maxlength="255" placeholder="Archival Identifier" autocomplete="off" style="width: 250px;">


### PR DESCRIPTION
This PR makes the ID column on collections an auto-incrementing column. This includes scripts that:

1. loop through all collections and set their IDs sequentially
2. adjust the collection_id column of new_call_number_sequences
3. adjust the collection_id column of audio_visual items

Because of this, the ability to specify the ID by users has been removed when creating new collections and the ID column in the front end has been removed since it's now not related to the finding aid ID. 