### PR TITLE
APPDEV-8641 fixing bug with collection ID instead of archival identifier

### DIFF
--- a/app/Import/ItemsImport.php
+++ b/app/Import/ItemsImport.php
@@ -247,8 +247,9 @@ class ItemsImport extends Import {
     return Collection::where('archival_identifier', $archivalIdentifier)->exists();
   }
 
-  private function callNumberSequenceExists($collectionId, $formatId)
+  private function callNumberSequenceExists($archivalIdentifier, $formatId)
   {
+    $collectionId = Collection::where('archival_identifier', $archivalIdentifier)->first()->id;
     return CallNumberSequence::next($collectionId, $formatId) !== null;
   }
 


### PR DESCRIPTION
This PR fixes the validation so that it correctly passes in the collection ID, which it finds via the archival identifier.