### PR TITLE
APPDEV-9038 find collection ID via query

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             sudo rm -rf /var/lib/apt/lists/*
             sudo docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
             sudo docker-php-ext-install ldap
-            sudo apt-get install lsof
+            sudo apt-get install lsof -y
 
       - run: sudo composer self-update
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,11 @@ jobs:
             sudo apt-get update -y
             sudo docker-php-ext-install zip
             sudo docker-php-ext-install pdo_mysql
-            sudo apt install -y mysql-client
+            sudo apt-get install -y mysql-client
             sudo apt-get install libldap2-dev -y
             sudo rm -rf /var/lib/apt/lists/*
             sudo docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
             sudo docker-php-ext-install ldap
-            sudo apt-get install lsof -y
 
       - run: sudo composer self-update
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - run:
           name: Install PHP & other exts
           command: |
+            sudo apt-get update -y
             sudo docker-php-ext-install zip
             sudo docker-php-ext-install pdo_mysql
             sudo apt install -y mysql-client
@@ -30,7 +31,6 @@ jobs:
             sudo rm -rf /var/lib/apt/lists/*
             sudo docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
             sudo docker-php-ext-install ldap
-            sudo apt-get update -y
             sudo apt-get install lsof
 
       - run: sudo composer self-update

--- a/app/Http/Controllers/Admin/CollectionsController.php
+++ b/app/Http/Controllers/Admin/CollectionsController.php
@@ -57,8 +57,6 @@ class CollectionsController extends Controller
       // Update MySQL
       DB::transaction(function () use ($collection) {
         $collection->save();
-        // need to query the DB for the just-saved object's ID
-        $collectionId = Collection::where('archival_identifier', $collection->archival_identifier)->first()->id;
 
         // Since this is a new collection, create new sequences
         // for all prefixes with the same collection type ID
@@ -70,7 +68,7 @@ class CollectionsController extends Controller
           $prefix = $result->label;
           $sequence = new NewCallNumberSequence;
           $sequence->prefix = $prefix;
-          $sequence->collectionId = $collectionId;
+          $sequence->collectionId = $collection->id;
           $sequence->archivalIdentifier = $collection->archivalIdentifier;
           $sequence->next = 1;
           $sequence->save();

--- a/app/Http/Controllers/Admin/CollectionsController.php
+++ b/app/Http/Controllers/Admin/CollectionsController.php
@@ -57,8 +57,10 @@ class CollectionsController extends Controller
       // Update MySQL
       DB::transaction(function () use ($collection) {
         $collection->save();
+        // need to query the DB for the just-saved object's ID
+        $collectionId = Collection::where('archival_identifier', $collection->archival_identifier)->first()->id;
 
-        // Since this is a new collection, create new sequences 
+        // Since this is a new collection, create new sequences
         // for all prefixes with the same collection type ID
         $results = DB::table('prefixes')->select('label')
                                         ->where('collection_type_id', '=', $collection->collection_type_id)
@@ -68,7 +70,7 @@ class CollectionsController extends Controller
           $prefix = $result->label;
           $sequence = new NewCallNumberSequence;
           $sequence->prefix = $prefix;
-          $sequence->collectionId = $collection->id;
+          $sequence->collectionId = $collectionId;
           $sequence->archivalIdentifier = $collection->archivalIdentifier;
           $sequence->next = 1;
           $sequence->save();

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -10,9 +10,7 @@ class Collection extends Model {
 
   protected $dates = array('deleted_at');
 
-  protected $fillable = array('id', 'name', 'collectionTypeId', 'archivalIdentifier');
-
-  public $incrementing = false;
+  protected $fillable = array('name', 'collectionTypeId', 'archivalIdentifier');
 
   public function audioVisualItems()
   {


### PR DESCRIPTION
When adding new collections, it was discovered that the mechanism to create new call numbers was missing the collection's ID. Previously, when it was not auto-incrementing, the ID was specified so it was included in the newly created collection's attributes. Now, it is set by the DB when saved. 

This PR removed the ID column from the $fillable attributes array and removed the line that said not to auto-increment the ID (which was no longer working anyway).