### PR TITLE
APPDEV-9039 added collection type name to json response

### DIFF
--- a/app/Http/Controllers/Admin/CollectionsController.php
+++ b/app/Http/Controllers/Admin/CollectionsController.php
@@ -75,6 +75,7 @@ class CollectionsController extends Controller
         }
       });
 
+      $collection['collectionTypeName'] = $collection->collectionType->name;
       return response()->json($collection);
     }
   }

--- a/resources/views/admin/_collections.blade.php
+++ b/resources/views/admin/_collections.blade.php
@@ -34,9 +34,9 @@
     {{--Need the surrounding div here to keep the form displaying inline--}}
     <div id="new-record-form" class="hidden">
       <form class="form-inline">
+        <input type="text" name="archivalIdentifier" class="form-control form-control-sm" maxlength="255" placeholder="Archival Identifier" autocomplete="off" style="width: 150px;">
         <input type="text" name="name" class="form-control form-control-sm" maxlength="255" placeholder="Name" autocomplete="off" style="width: 250px;">
         {!! Form::select('collectionTypeId', $collectionTypes, null, array('class' => 'form-control form-control-sm')) !!}
-        <input type="text" name="archivalIdentifier" class="form-control form-control-sm" maxlength="255" placeholder="Archival Identifier" autocomplete="off" style="width: 250px;">
         <button class="btn btn-sm btn-secondary popover-submit" type="submit"><i class="fa fa-fw fa-check" aria-hidden="true"></i></button>
         <button class="btn btn-sm btn-secondary cancel-new-record"><i class="fa fa-fw fa-ban" aria-hidden="true"></i></button>
       </form>


### PR DESCRIPTION
When creating a new collection, it was incorrectly displaying the collection type name of the previous first column instead of its own. This adds the info to the json response so that the view can display the correct info.