### PR TITLE
APPDEV-9228 fixing the flash message that wasn't showing up

### DIFF
--- a/app/Http/Requests/ItemRequest.php
+++ b/app/Http/Requests/ItemRequest.php
@@ -25,7 +25,7 @@ class ItemRequest extends Request {
   {
     // Add rules for base audio visual item
     $rules = array();
-    $rules['batchSize'] = 'required_if:batch,1|integer|between:2,100';
+    $rules['batch_size'] = 'required_if:batch,1|integer|between:2,100';
     if ($this->route()->getName()!=='items.store') {
       $this->addRuleIfNotMixed($rules, 'call_number',
         'required|min:4|max:30|unique:audio_visual_items,call_number,'.


### PR DESCRIPTION
When specifying the batch option, if no batch size is provided, then the form should flash a message (see screen shot).

![Screen Shot 2020-01-22 at 2 08 55 PM](https://user-images.githubusercontent.com/6546457/72932977-d506bd00-3d2e-11ea-8767-037bcc75c243.png)

It looks like the request is specifying batchSize but the error handling is looking for batch_size. so the flash message doesn't work. It just redirects back to the form with no other messaging. This PR fixes that.
