### PR TITLE
APPDEV-9204 fixing the camelcased field name to snake-case to match t…

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -243,7 +243,7 @@ jitterbug = {
               // there is something to click on
               var newCellValue = data[field] == '' ? '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' : data[field];
               // if it's the collection type ID column, display the name instead of the ID
-              if (field === 'collectionTypeId') {
+              if (field === 'collection_type_id') {
                 newCellValue = data['collectionTypeName']
               }
               $(this).html(newCellValue);


### PR DESCRIPTION
…he view

The collection type name wasn't appearing in the ajaxed response because the view has the snake-cased field name. This should have been updated in the camelCasing ticket but was missed. Now that it's changed, the collection type name appears immediately after the ajax response is successful.