### PR TITLE
updating mysql connector file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,10 @@ jobs:
           name: Get and hook up connector file
           command: |
             cd ~/jitterbug
-            sudo wget --no-verbose -nc http://www.mirrorservice.org/sites/ftp.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.17.zip
-            sudo unzip -n mysql-connector-java-8.0.17.zip
+            sudo wget --no-verbose -nc http://www.mirrorservice.org/sites/ftp.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.19.zip
+            sudo unzip -n mysql-connector-java-8.0.19.zip
             cd /
-            sudo cp ~/jitterbug/mysql-connector-java-8.0.17/mysql-connector-java-8.0.17.jar /opt/solr/contrib/dataimporthandler-extras/lib/.
+            sudo cp ~/jitterbug/mysql-connector-java-8.0.19/mysql-connector-java-8.0.19.jar /opt/solr/contrib/dataimporthandler-extras/lib/.
 
       - run:
           name: Change solr home directory

--- a/after.sh
+++ b/after.sh
@@ -27,12 +27,12 @@ sudo ./install_solr_service.sh solr-7.2.1.tgz
 
 # Get the MySQL connector file and unzip it if needed
 cd /vagrant
-sudo wget --no-verbose -nc http://www.mirrorservice.org/sites/ftp.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.17.zip
-sudo unzip -n mysql-connector-java-8.0.17.zip
+sudo wget --no-verbose -nc http://www.mirrorservice.org/sites/ftp.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.19.zip
+sudo unzip -n mysql-connector-java-8.0.19.zip
 
 # Copy the MySQL connector file to the right place
 cd /
-sudo cp /vagrant/mysql-connector-java-8.0.17/mysql-connector-java-8.0.17.jar /opt/solr/contrib/dataimporthandler-extras/lib/.
+sudo cp /vagrant/mysql-connector-java-8.0.19/mysql-connector-java-8.0.19.jar /opt/solr/contrib/dataimporthandler-extras/lib/.
 
 # Change users/groups/permissions of Solr home directory files
 cd /opt/solr


### PR DESCRIPTION
the `mysql-connector-java-8.0.17.zip` is no longer available so this changes the package to a newer version