### PR TITLE
Appdev 9263 accession number migration

### DIFF
--- a/app/Http/Requests/ItemRequest.php
+++ b/app/Http/Requests/ItemRequest.php
@@ -34,7 +34,7 @@ class ItemRequest extends Request {
     $this->addRuleIfNotMixed($rules, 'title', 'required|min:3|max:255');
     $this->addRuleIfNotMixed($rules, 'container_note', 'max:1000');
     $this->addRuleIfNotMixed($rules, 'collection_id', 'required');
-    $this->addRuleIfNotMixed($rules, 'accession_number', 'integer|digits_between:0,15');
+    $this->addRuleIfNotMixed($rules, 'accession_number', 'max:255');
     $this->addRuleIfNotMixed($rules, 'legacy', 'max:255');
     $this->addRuleIfNotMixed($rules, 'format_id', 'required');
     $this->addRuleIfNotMixed($rules, 'reel_tape_number', 'max:255');
@@ -89,7 +89,7 @@ class ItemRequest extends Request {
       // Messages for audio visual item fields
       'format_id.required' => 'The format field is required.',
       'reel_tape_number.max' => ' The reel/tape number field must be less than :max characters.',
-      'accession_number.digits_between' => 'The accession number must be less than :max digits.',
+      'accession_number.max' => 'The accession number must be less than :max characters.',
       'legacy.max' => 'The legacy id field must be less than :max characters.',
       'collection_id.required' => 'The collection field is required.',
       'physical_location.max' => ' The physical location field must be less than :max characters.',

--- a/app/Import/ItemsImport.php
+++ b/app/Import/ItemsImport.php
@@ -65,11 +65,6 @@ class ItemsImport extends Import {
           && !empty($row[$key]) && !$this->collectionExists($row[$key])) {
           $bag->add($key, $key . ' must already exist in the database.');
         }
-        // Validate accession number is an integer
-        if ($key==='AccessionNumber' 
-          && !empty($row[$key]) && !ctype_digit($row[$key])) {
-          $bag->add($key, $key . ' must be an integer.');
-        }
         // Validate format exists
         if ($key==='FormatID' 
           && !empty($row[$key]) && !$this->formatExists($row[$key])) {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -77,7 +77,7 @@ $factory->define(Jitterbug\Models\AudioVisualItem::class, function (Faker\Genera
     'collection_id' => function () {
       return factory(Jitterbug\Models\Collection::class)->create()->id;
     },
-    'accession_number' => $faker->randomNumber(),
+    'accession_number' => $faker->word,
     'legacy' => null,
     'container_note' => $faker->text,
     'condition_note' => $faker->text,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -77,7 +77,7 @@ $factory->define(Jitterbug\Models\AudioVisualItem::class, function (Faker\Genera
     'collection_id' => function () {
       return factory(Jitterbug\Models\Collection::class)->create()->id;
     },
-    'accession_number' => $faker->word,
+    'accession_number' => $faker->bothify('##??#???###?#?#'),
     'legacy' => null,
     'container_note' => $faker->text,
     'condition_note' => $faker->text,

--- a/database/migrations/2020_02_12_190752_change_accession_number_to_string.php
+++ b/database/migrations/2020_02_12_190752_change_accession_number_to_string.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeAccessionNumberToString extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('audio_visual_items', function (Blueprint $table) {
+            $table->string('accession_number', 255)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('audio_visual_items', function (Blueprint $table) {
+            $table->integer('accession_number')->change();
+        });
+    }
+}


### PR DESCRIPTION
This PR includes the migration to change the accession_number column from integer to string, since the accession numbers coming from ArchivesSpace now look like "20200110.1" instead of whole numbers.

The validations and factories are also adjusted to accommodate this change.