### PR TITLE
APPDEV-9342 correctly displaying validation custom error message and …

### DIFF
--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -14,7 +14,7 @@ sites:
     -
         map: homestead.test
         to: /home/vagrant/code/public
-        php: "5.6"
+        php: "7.3"
 databases:
     - homestead
 name: jitterbug

--- a/app/Http/Requests/PlaybackMachineRequest.php
+++ b/app/Http/Requests/PlaybackMachineRequest.php
@@ -1,10 +1,5 @@
 <?php namespace Jitterbug\Http\Requests;
 
-use Log;
-
-use Illuminate\Routing\Route;
-
-use Jitterbug\Http\Requests\Request;
 
 class PlaybackMachineRequest extends Request {
 

--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Validation\ValidationException;
 
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -263,14 +263,15 @@ jitterbug = {
             // Validation error
             if (jqXHR.status==422) {
               var errors = JSON.parse(jqXHR.responseText);
+              var errorMessage = errors['errors']['name'][0];
               // Get the first error, no matter which it is.
-              for (var key in errors) if (errors.hasOwnProperty(key)) break;
+
               // Unfortunately, we have to hide the popover here
               // because it doesn't stay pinned to the field it
               // relates to when the alert div is opened (a bug
               // in Bootstrap/Tether).
               jitterbug.displayAlert('danger',
-                  '<strong>Whoops.</strong> ' + errors[key]);
+                  '<strong>Whoops.</strong> ' + errorMessage);
             } else {
               jitterbug.displayAlert('danger',
                   '<strong>Uh oh.</strong> An error has occurred: ' + error);


### PR DESCRIPTION
…fixing homestead VM config

When trying to create new objects in the admin interface, the custom validation error message was not showing. Instead the flash message would just say "Whoops. The given data is invalid." instead of, for example "Whoops. The playback machine name must be at least 2 characters."

This PR fixes it by adjusting to the new validation error structure introduced in the PHP upgrade, which looks like:
`{"message":"The given data was invalid.","errors":{"name":["The playback machine name must be at least 2 characters."]}}`