### PR TITLE
APPDEV-9355 added track config to transfer audio imports upload

### DIFF
--- a/app/Models/Transfer.php
+++ b/app/Models/Transfer.php
@@ -18,7 +18,7 @@ class Transfer extends Model {
     'CallNumber', 'OriginatorReference', 'Side',
     'PlaybackMachine', 'FileSize', 'Duration',
     'OriginationDate', 'TransferNote', 'IART',
-    'OriginalPM', 'Size'
+    'OriginalPM', 'Size', 'TrackConfiguration'
   ];
   const VIDEO_IMPORT_KEYS = [
     'CallNumber', 'FileName', 'Codec', 'Duration',

--- a/tests/Feature/TransferAudioImportsTest.php
+++ b/tests/Feature/TransferAudioImportsTest.php
@@ -24,7 +24,7 @@ class TransferAudioImportsTest extends TestCase
       $this->audioVisualItem1 = factory(Jitterbug\Models\AudioVisualItem::class)->create(['call_number' =>'FT-6708']);
       $this->audioVisualItem2 = factory(Jitterbug\Models\AudioVisualItem::class)->create(['call_number' =>'FT-6709']);
       $this->playbackMachine = factory(Jitterbug\Models\PlaybackMachine::class)->create(['name' => 'Otari 19462235 D']);
-      factory(Jitterbug\Models\AudioItem::class)->create(['size' => '7"']);
+      factory(Jitterbug\Models\AudioItem::class)->create(['size' => '7"', 'track_configuration' => '1/2 track']);
     }
 
     public function testAudioImportUpload()
@@ -100,5 +100,25 @@ class TransferAudioImportsTest extends TestCase
 
     $this->assertEquals('success', $responseArray['status'], "The JSON status should be 'success'.");
     $this->assertEquals('7"', $audioItem->size, 'The size column in the related AudioItem was not set correctly.');
+  }
+
+  public function testAudioImportUploadUpdateTrackConfigWithSuccess()
+  {
+    $user = $this->user;
+    $avItem = $this->audioVisualItem1;
+    $filePath = base_path('tests/import-test-files/audio-import/small_upload_file_no_errors.csv');
+
+    $response = $this->actingAs($user)
+      ->withSession(['audio-import-file' => $filePath])
+      ->post('/transfers/batch/audio-import-execute',
+        [],
+        array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
+
+    $responseArray = json_decode($response->getContent(), true);
+    $audioItem = $avItem->subclass;
+
+    $this->assertEquals('success', $responseArray['status'], "The JSON status should be 'success'.");
+    $this->assertEquals('1/2 track', $audioItem->track_configuration,
+      'The track configuration column in the related AudioItem was not set correctly.');
   }
 }

--- a/tests/import-test-files/audio-import/small_upload_file_no_errors.csv
+++ b/tests/import-test-files/audio-import/small_upload_file_no_errors.csv
@@ -1,3 +1,3 @@
-OriginalPm,CallNumber,Side,PlaybackMachine,OriginatorReference,OriginationDate,IART,FileSize,Duration,TransferNote,Size
-,FT-6708,1,Otari 19462235 D,FT6708_1_PM,2019-04-07,SFC,43546,00:33:12.69,this is a note,"7"""
-,FT-6709,1,Otari 19462235 D,FT6709_1_PM,2019-04-07,SFC,43546,00:33:14.79,and another one,
+OriginalPm,CallNumber,Side,PlaybackMachine,OriginatorReference,OriginationDate,IART,FileSize,Duration,TransferNote,Size,TrackConfiguration
+,FT-6708,1,Otari 19462235 D,FT6708_1_PM,2019-04-07,SFC,43546,00:33:12.69,this is a note,"7""",1/2 track
+,FT-6709,1,Otari 19462235 D,FT6709_1_PM,2019-04-07,SFC,43546,00:33:14.79,and another one,,1/2 track


### PR DESCRIPTION
This PR includes the code necessary for the TrackConfiguration column in audio imports upload. The front end, the CSV upload and validation, executing the change in the DB, and a test.