### PR TITLE
APPDEV-add speed to audio imports

### DIFF
--- a/app/Models/Transfer.php
+++ b/app/Models/Transfer.php
@@ -19,7 +19,7 @@ class Transfer extends Model {
     'PlaybackMachine', 'FileSize', 'Duration',
     'OriginationDate', 'TransferNote', 'IART',
     'OriginalPM', 'Size', 'TrackConfiguration',
-    'Base'
+    'Base', 'Speed'
   ];
   const VIDEO_IMPORT_KEYS = [
     'CallNumber', 'FileName', 'Codec', 'Duration',

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -120,7 +120,6 @@ $factory->define(Jitterbug\Models\AudioVisualItemType::class, function (Faker\Ge
 
 $factory->define(Jitterbug\Models\Collection::class, function (Faker\Generator $faker) {
   return [
-    'id' => $faker->randomNumber(),
     'name' => $faker->name,
     'collection_type_id' => function () {
       return factory(Jitterbug\Models\CollectionType::class)->create()->id;
@@ -131,7 +130,6 @@ $factory->define(Jitterbug\Models\Collection::class, function (Faker\Generator $
 
 $factory->define(Jitterbug\Models\CollectionType::class, function (Faker\Generator $faker) {
   return [
-    'id' => $faker->randomNumber(),
     'name' => $faker->word,
   ];
 });

--- a/tests/import-test-files/audio-import/small_upload_file_no_errors.csv
+++ b/tests/import-test-files/audio-import/small_upload_file_no_errors.csv
@@ -1,3 +1,3 @@
-OriginalPm,CallNumber,Side,PlaybackMachine,OriginatorReference,OriginationDate,IART,FileSize,Duration,TransferNote,Size,TrackConfiguration,Base
-,FT-6708,1,Otari 19462235 D,FT6708_1_PM,2019-04-07,SFC,43546,00:33:12.69,this is a note,"7""",1/2 track,Polyester
-,FT-6709,1,Otari 19462235 D,FT6709_1_PM,2019-04-07,SFC,43546,00:33:14.79,and another one,,1/2 track
+OriginalPm,CallNumber,Side,PlaybackMachine,OriginatorReference,OriginationDate,IART,FileSize,Duration,TransferNote,Size,TrackConfiguration,Base,Speed
+,FT-6708,1,Otari 19462235 D,FT6708_1_PM,2019-04-07,SFC,43546,00:33:12.69,this is a note,"7""",1/2 track,Polyester,78 rpm
+,FT-6709,1,Otari 19462235 D,FT6709_1_PM,2019-04-07,SFC,43546,00:33:14.79,and another one,,1/2 track,,


### PR DESCRIPTION
This PR adds speed to the batch transfer audio items import. Now it checks whether the object is dirty before saving, since the audio item or the audio visual item might be changed. Also the items core in solr is updated if any of the audio visual items have been changed.

I've also removed some unnecessary ID specifications in the factories and added a new test.