### PR TITLE
Appdeb 9357 remove solr update

### DIFF
--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -30,7 +30,6 @@ class AudioImport extends Import {
 
   protected $solrMasters;
   protected $solrTransfers;
-  protected $solrItems;
 
   protected $data = null;
 
@@ -162,7 +161,6 @@ class AudioImport extends Import {
     // Keep track of which masters and transfers to update in Solr
     $masters = array();
     $transfers = array();
-    $items = array();
     $created = $updated = 0;
 
     // Update MySQL
@@ -353,7 +351,6 @@ class AudioImport extends Import {
           }
           if (!empty($row['Speed'])) {
             $audioVisualItem->speed = $row['Speed'];
-            $items[] = $audioVisualItem;
           }
 
           if ($audioItem->isDirty()) {
@@ -373,7 +370,6 @@ class AudioImport extends Import {
 
     $this->solrMasters->update($masters);
     $this->solrTransfers->update($transfers);
-    $this->solrItems->update($items);
 
     return array('created' => $created, 'updated' => $updated);
   }

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -49,7 +49,6 @@ class AudioImport extends Import {
 
     $this->solrMasters = new SolariumProxy('jitterbug-masters');
     $this->solrTransfers = new SolariumProxy('jitterbug-transfers');
-    $this->solrItems = new SolariumProxy('jitterbug-items');
 
     $reader = new CsvReader($filePath);
     $this->data = $reader->fetchKeys($this->audioImportKeys);

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -164,7 +164,7 @@ class AudioImport extends Import {
 
     // Update MySQL
     DB::transaction( function () 
-      use (&$masters, &$transfers, &$items, &$created, &$updated) {
+      use (&$masters, &$transfers, &$created, &$updated) {
       $transactionId = Uuid::uuid4();
       DB::statement("set @transaction_id = '$transactionId';");
 


### PR DESCRIPTION
This PR removes the solr update because speed is not indexed by solr, so any changes to that column do not require solr to be updated.