### PR TITLE
APPDEV-9494 fixing typo that caused OriginalPm bug

### DIFF
--- a/app/Models/Transfer.php
+++ b/app/Models/Transfer.php
@@ -18,7 +18,7 @@ class Transfer extends Model {
     'CallNumber', 'OriginatorReference', 'Side',
     'PlaybackMachine', 'FileSize', 'Duration',
     'OriginationDate', 'TransferNote', 'IART',
-    'OriginalPM', 'Size', 'TrackConfiguration',
+    'OriginalPm', 'Size', 'TrackConfiguration',
     'Base', 'Speed'
   ];
   const VIDEO_IMPORT_KEYS = [


### PR DESCRIPTION
An uppercase M should be a lowercase m to match code in audio transfers import upload.