### PR TITLE
Appdev 9523 import action backfill script

### DIFF
--- a/app/Console/Commands/BackfillImportActions.php
+++ b/app/Console/Commands/BackfillImportActions.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jitterbug\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class BackfillImportActions extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backfill:import_actions';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sets update import action for previous appropriate ImportTransactions';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/app/Console/Commands/BackfillImportActions.php
+++ b/app/Console/Commands/BackfillImportActions.php
@@ -48,14 +48,13 @@ class BackfillImportActions extends Command
             ->where('transaction_id', $importTransaction->transaction_id)->get();
           // determine unique field values
           $fields = $relatedRevisions->pluck('field')->unique();
+          // if any of the fields are created_at, then it's a create, so skip
           if ($fields->contains('created_at')) {
             continue;
           }
-          // if none of the fields are 'created_at' it's an update
-          if ($fields->diff('created_at')->count() === 0) {
-            $importTransaction->import_action = 'update';
-            $importTransaction->save();
-          }
+          // otherwise set the import action to update
+          $importTransaction->import_action = 'update';
+          $importTransaction->save();
         }
         $bar->finish();
     }


### PR DESCRIPTION
This PR contains the script for looping through all ~730 import transactions and setting the import_action to 'update' if appropriate. It loops through the related revisions (by transaction_id) and scans the fields that were changed in the revision.

If any of the fields are 'created_at' then the import was a create. If none of the fields are 'created_at' then it was an update. In the VM DB there are only seven of these, which lines up with what Erica has mentioned about the frequency of update imports.