### PR TITLE
APPDEV-9572 fix syntax error so that logging can write to the right d…

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -43,7 +43,7 @@ return [
 
     'single' => [
       'driver' => 'single',
-      'path' => storage_path(env('LOG_CHANNEL_PATH','logs/laravel.log')),
+      'path' => env('LOG_CHANNEL_PATH',storage_path('logs/laravel.log')),
       'level' => 'debug',
     ],
 


### PR DESCRIPTION
…irectory if single channel is chosen

I put the `storage_path(` in the wrong place, whoops 😅 