### PR TITLE
Appdev 9524 update transaction digest for update imports

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -88,15 +88,8 @@ class Activity extends Model {
   public function object()
   {
     if (Str::contains($this->action, 'import')) {
-      if ($this->import_type === 'audio') {
-        return 'batch of ' . $this->batch_size . ' audio records';
-      } else if ($this->import_type === 'film') {
-        return 'batch of ' . $this->batch_size . ' film records';
-      } else if ($this->import_type === 'video') {
-        return 'batch of ' . $this->batch_size . ' video records';
-      } else if ($this->import_type === 'items') {
-        return 'batch of ' . $this->batch_size . ' audio visual item records';
-      }
+      $type = $this->import_type === 'items' ? 'audio visual item' : $this->import_type;
+      return 'batch of ' . $this->batch_size . ' ' . $type . ' records';
     }
 
     $objectType = $this->objectType();

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -1,5 +1,6 @@
 <?php namespace Jitterbug\Models;
 
+use Illuminate\Support\Str;
 use Log;
 
 use Illuminate\Database\Eloquent\Model;
@@ -86,14 +87,16 @@ class Activity extends Model {
    */
   public function object()
   {
-    if ($this->action === 'imported' && $this->import_type === 'audio') {
-      return 'batch of ' . $this->batch_size . ' audio records';
-    } else if ($this->action === 'imported' && $this->import_type === 'film') {
-      return 'batch of ' . $this->batch_size . ' film records';
-    } else if ($this->action === 'imported' && $this->import_type === 'video') {
-      return 'batch of ' . $this->batch_size . ' video records';
-    } else if ($this->action === 'imported' && $this->import_type === 'items') {
-      return 'batch of ' . $this->batch_size . ' audio visual item records';
+    if (Str::contains($this->action, 'import')) {
+      if ($this->import_type === 'audio') {
+        return 'batch of ' . $this->batch_size . ' audio records';
+      } else if ($this->import_type === 'film') {
+        return 'batch of ' . $this->batch_size . ' film records';
+      } else if ($this->import_type === 'video') {
+        return 'batch of ' . $this->batch_size . ' video records';
+      } else if ($this->import_type === 'items') {
+        return 'batch of ' . $this->batch_size . ' audio visual item records';
+      }
     }
 
     $objectType = $this->objectType();


### PR DESCRIPTION
This PR fixes two bugs:
- the activity object determination was dependent on the old "imported" action which now no longer applies, because the import action is now "created via import" or "updated via import". also DRYed up the logic
- the count previously only counted PreservationMaster revisions. now that the new columns have been added to the import that affect AudioVisualItems and AudioItems, those are now included