### PR TITLE
APPDEV-9628 fixing camelCased field name to snake_case

### DIFF
--- a/app/Presenters/TransactionDigest.php
+++ b/app/Presenters/TransactionDigest.php
@@ -261,7 +261,7 @@ class TransactionDigest
       }
       return;
     } else if ($this->action === 'updated' && !$this->batch) {
-      $activity->numFields = $this->revisions->count();
+      $activity->num_fields = $this->revisions->count();
     }
 
     $this->activities[] = $activity;

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"laravel/framework": "6.0.*",
 		"laravelcollective/html": "6.0.*",
 		"solarium/solarium": "^5.1",
-		"venturecraft/revisionable": "dev-master",
+		"venturecraft/revisionable": "dev-main",
 		"davejamesmiller/laravel-breadcrumbs": "^5.0",
 		"ramsey/uuid": "^3.5",
 		"adldap2/adldap2-laravel": "6.0.*",

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -307,6 +307,7 @@ $factory->define(Jitterbug\Models\Project::class, function (Faker\Generator $fak
 
 $factory->define(Venturecraft\Revisionable\Revision::class, function (Faker\Generator $faker) {
   return [
+    'field' => $faker->word,
     'revisionable_type' => 'AudioVisualItem',
     'revisionable_id' => function () {
       return factory(Jitterbug\Models\AudioVisualItem::class)->create()->id;


### PR DESCRIPTION
This typo was preventing the ActivityStream from generating correctly. It fixes the error found in the log:
`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'numFields' in 'field list'`
