### PR TITLE
Appdev 8481 blank check box av items

### DIFF
--- a/app/Models/AudioItem.php
+++ b/app/Models/AudioItem.php
@@ -42,7 +42,7 @@ class AudioItem extends Model {
 
   public function getListeningCopyDisplayAttribute($value)
   {
-    $listeningCopy = ($value===null ? $this->listening_copy : $value);
+    $listeningCopy = $value ?? $this->listening_copy;
     if($listeningCopy) {
       return 'Yes';
     } else {
@@ -52,7 +52,7 @@ class AudioItem extends Model {
 
   public function getMonoStereoDisplayAttribute($value)
   {
-    $monoStereo = ($value===null ? $this->mono_stereo : $value);
+    $monoStereo = $value ?? $this->mono_stereo;
     if($monoStereo==='M') {
       $monoStereo = 'Mono';
     } else if($monoStereo==='S')  {
@@ -73,7 +73,7 @@ class AudioItem extends Model {
 
   public function getAudioMonoStereoAttribute($value)
   {
-    return $value===null ? $this->mono_stereo : $value;
+    return $value ?? $this->mono_stereo;
   }
 
   public function setAudioMonoStereoAttribute($value)
@@ -83,7 +83,7 @@ class AudioItem extends Model {
 
   public function getAudioBaseAttribute($value)
   {
-    return $value===null ? $this->base : $value;
+    return $value ?? $this->base;
   }
 
   public function setAudioBaseAttribute($value)
@@ -93,7 +93,7 @@ class AudioItem extends Model {
 
   public function getAudioContentDescriptionAttribute($value)
   {
-    return $value===null ? $this->content_description : $value;
+    return $value ?? $this->content_description;
   }
 
   public function setAudioContentDescriptionAttribute($value)

--- a/app/Models/AudioVisualItem.php
+++ b/app/Models/AudioVisualItem.php
@@ -64,7 +64,7 @@ class AudioVisualItem extends Model {
     'recording_location', 'physical_location', 'access_restrictions',
     'item_year', 'item_date', 'collection_id', 'accession_number',
     'legacy', 'format_id', 'reel_tape_number', 'container_note',
-    'condition_note', 'oclc', 'entry_date', 'speed');
+    'condition_note', 'oclc', 'entry_date', 'speed', 'blank');
 
   public function __construct($attributes = [])
   {
@@ -134,8 +134,11 @@ class AudioVisualItem extends Model {
     }
   }
 
-  public function getBlankDisplayAttribute() : string
+  public function getBlankDisplayAttribute($value) : string
   {
-    return $this->blank ? 'Yes' : 'No';
+    // the param $value is required for revisionable revision history
+    // it may be blank due to usage in AV items show page
+    $blank = $value ?? $this->blank;
+    return $blank ? 'Yes' : 'No';
   }
 }

--- a/app/Models/AudioVisualItem.php
+++ b/app/Models/AudioVisualItem.php
@@ -134,4 +134,8 @@ class AudioVisualItem extends Model {
     }
   }
 
+  public function getBlankDisplayAttribute() : string
+  {
+    return $this->blank ? 'Yes' : 'No';
+  }
 }

--- a/database/migrations/2020_07_08_183918_add_blank_to_audio_visual_items.php
+++ b/database/migrations/2020_07_08_183918_add_blank_to_audio_visual_items.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddBlankToAudioVisualItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('audio_visual_items', function (Blueprint $table) {
+          $table->boolean('blank')->default(0)->after('subclass_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('audio_visual_items', function (Blueprint $table) {
+          $table->dropColumn('blank');
+        });
+    }
+}

--- a/resources/views/items/_form-common.blade.php
+++ b/resources/views/items/_form-common.blade.php
@@ -221,5 +221,25 @@
           </div>
         </div>
       </div>
+      <div class="row">
+        <div class="form-group">
+          <div class="col-xs-4 col-xs-offset-1 detail-label">
+            {!! Form::label('blank', 'Blank?', array('class' => 'form-control-label')) !!}
+          </div>
+          <div class="col-xs-7 detail-value">
+            @if ($item->blank !== '<mixed>' || !$item->batch())
+              <label class="radio-inline">
+                {!! Form::radio('blank', '1') !!} Yes
+              </label>
+              <label class="radio-inline">
+                {!! Form::radio('blank', '0', true) !!} No
+              </label>
+            @else
+              {!! Form::select('blank',
+              array('1' => 'Yes', '0' => 'No', '<mixed>' => '<mixed>'), $item->blank, array('class' => 'form-control form-control-sm')) !!}
+            @endif
+          </div>
+        </div>
+      </div>
       {{-- End AudioVisualItem fields --}}
  

--- a/resources/views/items/show.blade.php
+++ b/resources/views/items/show.blade.php
@@ -176,6 +176,14 @@
         </div>
       </div>
       @endif
+      <div class="row">
+        <div class="col-xs-4 col-xs-offset-1 detail-label">
+          Blank?
+        </div>
+        <div class="col-xs-7 detail-value">
+          {{$item->blank_display}}
+        </div>
+      </div>
       {{-- End AudioVisualItem fields --}}
     </div>
     <div class="col-xs-6">

--- a/tests/Unit/AudioVisualItemTest.php
+++ b/tests/Unit/AudioVisualItemTest.php
@@ -1,5 +1,6 @@
 <?php
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Jitterbug\Models\AudioVisualItem;
 
 class AudioVisualItemTest extends TestCase
 {
@@ -9,13 +10,13 @@ class AudioVisualItemTest extends TestCase
      *
      * @return void
      */
-    public function testTypeIdAttribute()
+    public function testTypeIdAttribute() : void
     {
-      $av_audio_item = factory(Jitterbug\Models\AudioVisualItem::class)->make();
-      $av_film_item = factory(Jitterbug\Models\AudioVisualItem::class)->make([
+      $av_audio_item = factory(AudioVisualItem::class)->make();
+      $av_film_item = factory(AudioVisualItem::class)->make([
         'subclass_type' => 'FilmItem',
       ]);
-      $av_video_item = factory(Jitterbug\Models\AudioVisualItem::class)->make([
+      $av_video_item = factory(AudioVisualItem::class)->make([
         'subclass_type' => 'VideoItem',
       ]);
 
@@ -23,5 +24,21 @@ class AudioVisualItemTest extends TestCase
       $this->assertSame(2, $av_film_item->getTypeIdAttribute(), 'TypeIdAttribute returned wrong ID for Film Item');
       $this->assertSame(3, $av_video_item->getTypeIdAttribute(), 'TypeIdAttribute returned wrong ID for Video Item');
 
+    }
+
+    public function testBlankDisplayAttributeWithRevisionable() : void
+    {
+      $av_item = factory(AudioVisualItem::class)->make();
+
+      $this->assertSame('Yes', $av_item->getBlankDisplayAttribute(true),
+        'BlankDisplayAttribute should return yes when revisionable passes true in');
+    }
+
+    public function testBlankDisplayAttribute() : void
+    {
+      $av_item = factory(AudioVisualItem::class)->make(['blank' => true]);
+
+      $this->assertSame('Yes', $av_item->blank_display,
+        'BlankDisplayAttribute should return yes as the display form attribute');
     }
 }


### PR DESCRIPTION
This PR adds the migration for a new column, "blank" on audio visual items. For the front end, we needed a function that would display "yes" or "no" depending on the boolean value. This function would be used on the show page (via attribute magic) and would also be used by Revisionable code to display the corresponding revisions when the values are changed.

![Screen Shot 2020-07-13 at 3 11 06 PM](https://user-images.githubusercontent.com/6546457/87343767-5fc8b780-c51b-11ea-83a5-5d85db0d864b.png)
![Screen Shot 2020-07-13 at 3 11 12 PM](https://user-images.githubusercontent.com/6546457/87343769-60614e00-c51b-11ea-91f4-2ac34ff4f097.png)
![Screen Shot 2020-07-13 at 3 11 24 PM](https://user-images.githubusercontent.com/6546457/87343771-60614e00-c51b-11ea-83f9-6a55afa0fbd0.png)
