### PR TITLE
APPDEV-9644 correcting attribute name so that the default value is ac…

### DIFF
--- a/app/Import/ItemsImport.php
+++ b/app/Import/ItemsImport.php
@@ -312,7 +312,7 @@ class ItemsImport extends Import {
     $defaultBase = $isUpdate ? $subclass->base : null;
     $defaultColor = $isUpdate ? $subclass->color : null;
     $defaultSoundType = $isUpdate ? $subclass->sound_type : null;
-    $defaultLength = $isUpdate ? $subclass->length : null;
+    $defaultLength = $isUpdate ? $subclass->length_in_feet : null;
     $defaultContentDescription = $isUpdate ? $subclass->content_description : null;
 
     // if the array has a value for the attribute, use it. otherwise use the default


### PR DESCRIPTION
…tually the DB value instead of null

This PR corrects the name of an attribute field so that it will pull the right value from the DB instead of null (since the attribute `length` doesn't actually exist).