### PR TITLE
Appdev 9593 legacy collection script

### DIFF
--- a/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
+++ b/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Jitterbug\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Jitterbug\Models\NewCallNumberSequence;
+
+class SetCollectionToLegacyCallNumberSequence extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'reset_sequence:legacy {archival_identifier}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This script deletes all new_call_number_sequences of the specified archival identifier.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+      $archivalIdentifier = $this->argument('archival_identifier');
+
+      $invalidSequencePrefixes = DB::table('new_call_number_sequences')
+        ->where('archival_identifier', $archivalIdentifier)
+        ->where('next', '>', 1)
+        ->get()
+        ->pluck('prefix');
+
+      DB::table('new_call_number_sequences')
+        ->where('archival_identifier', $archivalIdentifier)
+        ->where('next', '=', 1)
+        ->delete();
+
+      if ($invalidSequencePrefixes->count() > 0) {
+        return 'The sequences with the following prefixes were not deleted: ' . $invalidSequencePrefixes;
+      }
+      return 'All sequences for archival identifier ' . $archivalIdentifier . ' were successfully deleted.';
+    }
+}

--- a/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
+++ b/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
@@ -53,8 +53,9 @@ class SetCollectionToLegacyCallNumberSequence extends Command
         ->delete();
 
       if ($invalidSequencePrefixes->count() > 0) {
-        return 'The sequences with the following prefixes were not deleted: ' . $invalidSequencePrefixes;
+        $this->info('Done! The sequences with the following prefixes were not deleted: ' . $invalidSequencePrefixes);
+      } else {
+        $this->info('All sequences for archival identifier ' . $archivalIdentifier . ' were successfully deleted.');
       }
-      return 'All sequences for archival identifier ' . $archivalIdentifier . ' were successfully deleted.';
     }
 }

--- a/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
+++ b/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
@@ -42,7 +42,7 @@ class SetCollectionToLegacyCallNumberSequence extends Command
       $archivalIdentifier = $this->argument('archival_identifier');
 
       // Find all new call number sequences that have been used and get their associated prefix
-      $invalidSequencePrefixes = DB::table('new_call_number_sequences')
+      $usedSequencePrefixes = DB::table('new_call_number_sequences')
         ->where('archival_identifier', $archivalIdentifier)
         ->where('next', '>', 1)
         ->get()
@@ -54,8 +54,8 @@ class SetCollectionToLegacyCallNumberSequence extends Command
         ->where('next', '=', 1)
         ->delete();
 
-      if ($invalidSequencePrefixes->count() > 0) {
-        $this->info('Done! The sequences with the following prefixes were not deleted: ' . $invalidSequencePrefixes);
+      if ($usedSequencePrefixes->count() > 0) {
+        $this->info('Done! The sequences with the following prefixes were not deleted because they have been used: ' . $usedSequencePrefixes);
       } else {
         $this->info('All sequences for archival identifier ' . $archivalIdentifier . ' were successfully deleted.');
       }

--- a/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
+++ b/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
@@ -45,7 +45,6 @@ class SetCollectionToLegacyCallNumberSequence extends Command
       $usedSequencePrefixes = DB::table('new_call_number_sequences')
         ->where('archival_identifier', $archivalIdentifier)
         ->where('next', '>', 1)
-        ->get()
         ->pluck('prefix');
 
       // Only delete the new call number sequences that have never been used

--- a/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
+++ b/app/Console/Commands/SetCollectionToLegacyCallNumberSequence.php
@@ -41,12 +41,14 @@ class SetCollectionToLegacyCallNumberSequence extends Command
     {
       $archivalIdentifier = $this->argument('archival_identifier');
 
+      // Find all new call number sequences that have been used and get their associated prefix
       $invalidSequencePrefixes = DB::table('new_call_number_sequences')
         ->where('archival_identifier', $archivalIdentifier)
         ->where('next', '>', 1)
         ->get()
         ->pluck('prefix');
 
+      // Only delete the new call number sequences that have never been used
       DB::table('new_call_number_sequences')
         ->where('archival_identifier', $archivalIdentifier)
         ->where('next', '=', 1)


### PR DESCRIPTION
This PR is for a script that will take a specified archival identifier and then find all new_call_number_sequences related to that archival identifier. 

For those new_call_number_sequences that have been used (where the "next" number isn't 1) it will collect the associated prefix into an array.

For those new_call_number_sequences that haven't been used, it will delete them.

The reason it will delete them is to force the call number generator to use the legacy call number sequence pattern instead. For example, for archival identifier 20188, a new call number sequence for prefix FT would be FT-20188/1. A legacy call number might be something like FT-1988. For certain collections we want it to follow legacy generation.