### PR TITLE
APPDEV-9755 creating ability to send in a duration value for revision…

### DIFF
--- a/app/Models/PreservationMaster.php
+++ b/app/Models/PreservationMaster.php
@@ -223,9 +223,10 @@ class PreservationMaster extends Model {
     $this->duration_in_seconds = DurationFormat::toSeconds($value);
   }
   
-  public function getDurationInSecondsDisplayAttribute()
+  public function getDurationInSecondsDisplayAttribute($value = null)
   {
-    return DurationFormat::toDuration($this->duration_in_seconds);
+    $duration = $value ?? $this->duration_in_seconds;
+    return DurationFormat::toDuration($duration);
   }
 }
 


### PR DESCRIPTION
…able to fix display bug

Revisionable was having trouble displaying the correctly formatted duration for PreservationMaster revisions. This was because Revisionable was relying on being able to send in the duration value to the function for formatting, which was not how the referenced function was written. This allows that to happen, with a default value of null, in case it's used elsewhere where a value isn't sent in.