### PR TITLE
APPDEV-9802 only check if call number seq is available if the format …

### DIFF
--- a/app/Import/ItemsImport.php
+++ b/app/Import/ItemsImport.php
@@ -55,6 +55,7 @@ class ItemsImport extends Import {
       $bag = new MessageBag();
       $messages[] = $bag;
       $callNumbers = array();
+      $formatExists = $this->formatExists($row['FormatID']);
       foreach($this->itemsImportKeys as $key) {
         // Validate that all required fields have values
         if (in_array($key, $this->requiredItemsImportKeys) 
@@ -73,12 +74,11 @@ class ItemsImport extends Import {
           }
         }
         // Validate format exists
-        if ($key==='FormatID' 
-          && !empty($row[$key]) && !$this->formatExists($row[$key])) {
+        if ($key==='FormatID' && !$formatExists) {
           $bag->add($key, $key . ' is not a recognized format.');
         }
         // Validate call number exists for Collection & Format pair
-        if (!empty($row['ArchivalIdentifier']) && !empty($row['FormatID']) &&
+        if (!empty($row['ArchivalIdentifier']) && $formatExists &&
           !$this->callNumberSequenceExists($row['ArchivalIdentifier'], $row['FormatID'])) {
           $bag->add('ArchivalIdentifier', 'The Collection/Format pairing does not have a valid CallNumberSequence available.');
           $bag->add('FormatID', 'The Collection/Format pairing does not have a valid CallNumberSequence available.');


### PR DESCRIPTION
…is valid

Certain CSV item imports weren't working because in the format ID column, there was a value of "VC-45" instead of an integer. This exposed the bug that even though the validation that the format wasn't valid was correctly recorded, the validator still tried to see if a valid call number sequence existed. This process includes finding the format via its specified ID, which eventually returns a 404 not found.

Now the logic only checks this if the format does in fact exist. That way, the validation will correctly show in the front end that the format doesn't exist. Before, jitterbug would just look like nothing happened because it eats all exceptions. =(