### PR TITLE
Appdev 9805 formats prefix bug

### DIFF
--- a/app/Http/Controllers/Admin/FormatsController.php
+++ b/app/Http/Controllers/Admin/FormatsController.php
@@ -2,7 +2,6 @@
 
 use Auth;
 use DB;
-use Log;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\MessageBag;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -280,7 +280,7 @@ jitterbug = {
               if (field === 'collection_type_id') {
                 newCellValue = data['collectionTypeName']
               } else if (field === 'prefixes') {
-                newCellValue = "Please edit prefixes.";
+                newCellValue = "Please add prefixes.";
               }
               $(this).html(newCellValue);
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -279,6 +279,8 @@ jitterbug = {
               // if it's the collection type ID column, display the name instead of the ID
               if (field === 'collection_type_id') {
                 newCellValue = data['collectionTypeName']
+              } else if (field === 'prefixes') {
+                newCellValue = "Please edit prefixes.";
               }
               $(this).html(newCellValue);
 

--- a/resources/views/admin/_formats.blade.php
+++ b/resources/views/admin/_formats.blade.php
@@ -27,7 +27,7 @@
                 @foreach ($record->uniquePrefixLabels() as $prefix)
                   <span>{{$prefix}}</span>,&nbsp;
                 @endforeach
-                <a class="btn btn-sm btn-secondary pull-right" href="{{route('formats.show', ['id' => $record->id])}}">Edit Prefixes</a>
+                <a class="btn btn-sm btn-secondary pull-right" href="{{route('formats.show', ['formats' => $record->id])}}">Edit Prefixes</a>
               </td>
               <td><a href="#" role="button" class="delete" title="Delete record" style="float: right;"><i class="fa fa-times" aria-hidden="true"></i></a></td>
             </tr>

--- a/resources/views/admin/_formats.blade.php
+++ b/resources/views/admin/_formats.blade.php
@@ -24,9 +24,11 @@
               {{--              <td><span class="editable" data-id="{{ $record->id }}" data-field="prefix" role="button">{{ $record->prefix }}</span></td>--}}
               {{--              <td><span class="editable" data-id="{{ $record->id }}" data-field="legacyPrefix" role="button">{{ empty($record->legacyPrefix) ? "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" : $record->legacyPrefix }}</span></td> --}}{{-- This is an optional field so we need those non-breaking spaces so there is something to click on --}}
               <td>
-                @foreach ($record->uniquePrefixLabels() as $prefix)
-                  <span>{{$prefix}}</span>,&nbsp;
-                @endforeach
+                <span data-field="prefixes">
+                  @foreach ($record->uniquePrefixLabels() as $prefix)
+                    {{$prefix}},&nbsp;
+                  @endforeach
+                </span>
                 <a class="btn btn-sm btn-secondary pull-right" href="{{route('formats.show', ['formats' => $record->id])}}">Edit Prefixes</a>
               </td>
               <td><a href="#" role="button" class="delete" title="Delete record" style="float: right;"><i class="fa fa-times" aria-hidden="true"></i></a></td>

--- a/resources/views/admin/_formats.blade.php
+++ b/resources/views/admin/_formats.blade.php
@@ -25,8 +25,9 @@
               {{--              <td><span class="editable" data-id="{{ $record->id }}" data-field="legacyPrefix" role="button">{{ empty($record->legacyPrefix) ? "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" : $record->legacyPrefix }}</span></td> --}}{{-- This is an optional field so we need those non-breaking spaces so there is something to click on --}}
               <td>
                 <span data-field="prefixes">
+                  @if ($record->uniquePrefixLabels() === []) Please add prefixes. @endif
                   @foreach ($record->uniquePrefixLabels() as $prefix)
-                    {{$prefix}},&nbsp;
+                    {{$prefix}},
                   @endforeach
                 </span>
                 <a class="btn btn-sm btn-secondary pull-right" href="{{route('formats.show', ['formats' => $record->id])}}">Edit Prefixes</a>


### PR DESCRIPTION
It was reported that when making a new format, what was listed under the prefixes was incorrect. Also the "Edit Prefixes" button led to a completely blank page.

It turns out that the ajax success takes the first format in the list, copies it, and replaces what it knows with the new format's fields. In this case there are not any connected prefixes yet so it just shows that model format's prefixes. This PR replaces it with a note to edit prefixes. 
![Screen Shot 2020-10-08 at 5 38 20 PM](https://user-images.githubusercontent.com/6546457/95516805-c8de9080-098d-11eb-8900-9f0f915c4081.png)

As for the blank page, that was the result of old laravel route helper syntax. Once that was updated, the page now loads again.
