### PR TITLE
Appdev 8643 delete columns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             sudo docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
             sudo docker-php-ext-install ldap
 
-      - run: sudo composer self-update
+      - run: sudo composer self-update --stable
       - run:
           name: Copy Circle CI version of .env.testing
           command: cp .env.testing.circleci .env.testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,10 @@ jobs:
           name: Get and hook up connector file
           command: |
             cd ~/jitterbug
-            sudo wget --no-verbose -nc http://www.mirrorservice.org/sites/ftp.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.19.zip
-            sudo unzip -n mysql-connector-java-8.0.19.zip
+            sudo wget --no-verbose -nc http://www.mirrorservice.org/sites/ftp.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.22.zip
+            sudo unzip -n mysql-connector-java-8.0.22.zip
             cd /
-            sudo cp ~/jitterbug/mysql-connector-java-8.0.19/mysql-connector-java-8.0.19.jar /opt/solr/contrib/dataimporthandler-extras/lib/.
+            sudo cp ~/jitterbug/mysql-connector-java-8.0.22/mysql-connector-java-8.0.22.jar /opt/solr/contrib/dataimporthandler-extras/lib/.
 
       - run:
           name: Change solr home directory

--- a/after.sh
+++ b/after.sh
@@ -27,12 +27,12 @@ sudo ./install_solr_service.sh solr-7.2.1.tgz
 
 # Get the MySQL connector file and unzip it if needed
 cd /vagrant
-sudo wget --no-verbose -nc http://www.mirrorservice.org/sites/ftp.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.19.zip
-sudo unzip -n mysql-connector-java-8.0.19.zip
+sudo wget --no-verbose -nc http://www.mirrorservice.org/sites/ftp.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.22.zip
+sudo unzip -n mysql-connector-java-8.0.22.zip
 
 # Copy the MySQL connector file to the right place
 cd /
-sudo cp /vagrant/mysql-connector-java-8.0.19/mysql-connector-java-8.0.19.jar /opt/solr/contrib/dataimporthandler-extras/lib/.
+sudo cp /vagrant/mysql-connector-java-8.0.19/mysql-connector-java-8.0.22.jar /opt/solr/contrib/dataimporthandler-extras/lib/.
 
 # Change users/groups/permissions of Solr home directory files
 cd /opt/solr

--- a/app/Http/Requests/FormatRequest.php
+++ b/app/Http/Requests/FormatRequest.php
@@ -50,8 +50,6 @@ class FormatRequest extends Request {
       'name.unique' => 'The format name has already been used.',
       'name.min' => 'The format name must be at least :min characters.',
       'name.max' => 'The format name must be less than :max characters.',
-      //TODO APPDEV-8643 remove when columns are removed
-      'legacy_prefix.max' => 'The legacy prefix name must be less than :max characters.',
     ];
   }
 

--- a/app/Http/Requests/FormatRequest.php
+++ b/app/Http/Requests/FormatRequest.php
@@ -33,8 +33,6 @@ class FormatRequest extends Request {
     return [
       'name' => $required . 'min:2|max:255|unique:formats,name,' .
          $this->route()->parameter('formats'),
-      'prefix' => $required . 'max:255',
-      'legacy_prefix' => 'max:255',
     ];
   }
 

--- a/app/Models/Format.php
+++ b/app/Models/Format.php
@@ -15,9 +15,9 @@ class Format extends Model {
   // Filters out formats that will not be used for new items
   public function scopeWithFutureUse($query)
   {
-    return $query->where('prefix', '<>', 'D')->
-                   where('prefix', '<>', 'DDVD');
-    }
+    return $query->where('id', '<>', 25)
+                 ->where('id', '<>', 54);
+  }
 
   public function audioVisualItems()
   {

--- a/app/Models/Prefix.php
+++ b/app/Models/Prefix.php
@@ -57,15 +57,10 @@ class Prefix extends Model
                                        ->first();
 
     if ($labelQuery === null) {
-      # TODO APPDEV-8643 remove when prefix column in formats table is deleted
-      # raise 404 error instead
-//      abort(404, 'Unable to find prefix for this format ID and collection ID.');
-      $label = Format::findOrFail($formatId)->prefix;
-    } else {
-      $label = $labelQuery->label;
+      abort(404, 'Unable to find prefix for this format ID and collection ID.');
     }
 
-    return $label;
+    return $labelQuery->label;
   }
 
   public static function possiblePrefixes($formatId)

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"laravel/framework": "6.0.*",
+		"laravel/framework": "6.18.*",
 		"laravelcollective/html": "6.0.*",
 		"solarium/solarium": "^5.1",
 		"venturecraft/revisionable": "dev-main",

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -186,8 +186,6 @@ $factory->define(Jitterbug\Models\FilmMaster::class, function (Faker\Generator $
 $factory->define(Jitterbug\Models\Format::class, function (Faker\Generator $faker) {
   return [
     'name' => $faker->word,
-    'prefix' => strtoupper($faker->lexify('??')),
-    'legacy_prefix' => strtoupper($faker->lexify('??')),
   ];
 });
 

--- a/database/migrations/2020_10_14_155824_delete_prefix_and_legacy_prefix_from_formats_table.php
+++ b/database/migrations/2020_10_14_155824_delete_prefix_and_legacy_prefix_from_formats_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DeletePrefixAndLegacyPrefixFromFormatsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+      Schema::table('formats', function (Blueprint $table) {
+        $table->dropColumn(['prefix', 'legacy_prefix']);
+      });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+      Schema::table('formats', function (Blueprint $table) {
+        $table->string('prefix', 255);
+        $table->string('legacy_prefix', 255)->nullable();
+      });
+    }
+}

--- a/resources/views/admin/_formats.blade.php
+++ b/resources/views/admin/_formats.blade.php
@@ -8,9 +8,6 @@
             <tr>
               <th width="8%">ID</th>
               <th width="30%">Name</th>
-              {{--  TODO APPDEV-8643 remove when unneeded columns are removed  --}}
-              {{--              <th width="15%">Prefix</th>--}}
-              {{--              <th width="15%">Legacy Prefix</th>--}}
               <th width="32%">Prefixes</th>
               <th width="5%"></th>
             </tr>
@@ -20,9 +17,6 @@
             <tr>
               <td><span data-field="id">{{ $record->id }}</td>
               <td><span class="editable" data-id="{{ $record->id }}" data-field="name" role="button">{{ $record->name }}</span></td>
-              {{--TODO APPDEV-8643 remove when columns are removed--}}
-              {{--              <td><span class="editable" data-id="{{ $record->id }}" data-field="prefix" role="button">{{ $record->prefix }}</span></td>--}}
-              {{--              <td><span class="editable" data-id="{{ $record->id }}" data-field="legacyPrefix" role="button">{{ empty($record->legacyPrefix) ? "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" : $record->legacyPrefix }}</span></td> --}}{{-- This is an optional field so we need those non-breaking spaces so there is something to click on --}}
               <td>
                 <span data-field="prefixes">
                   @if ($record->uniquePrefixLabels() === []) Please add prefixes. @endif
@@ -44,8 +38,6 @@
     <div id="new-record-form" class="hidden">
       <form class="form-inline">
         <input type="text" name="name" class="form-control form-control-sm" maxlength="255" placeholder="Name" autocomplete="off" style="width: 200px;">
-        <input type="text" name="prefix" class="form-control form-control-sm" maxlength="255" placeholder="Prefix" autocomplete="off" style="width: 110px;">
-        <input type="text" name="legacy_prefix" class="form-control form-control-sm" maxlength="255" placeholder="Legacy Prefix" autocomplete="off" style="width: 110px;">
         <button class="btn btn-sm btn-secondary popover-submit" type="submit"><i class="fa fa-fw fa-check" aria-hidden="true"></i></button>
         <button class="btn btn-sm btn-secondary cancel-new-record"><i class="fa fa-fw fa-ban" aria-hidden="true"></i></button>
       </form>

--- a/tests/Unit/CallNumberSequenceTest.php
+++ b/tests/Unit/CallNumberSequenceTest.php
@@ -1,6 +1,7 @@
 <?php
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Jitterbug\Models;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CallNumberSequenceTest extends TestCase
 {
@@ -16,23 +17,24 @@ class CallNumberSequenceTest extends TestCase
     $this->collectionType = factory(Models\CollectionType::class)->create(['name' => 'SFC Collection']);
     $this->prefix = factory(Models\Prefix::class)->create([
       'label' => $new_prefix_array[array_rand($new_prefix_array)],
-      'collection_type_id' => 3,
+      'collection_type_id' => $this->collectionType->id,
     ]);
     $this->collection = factory(Models\Collection::class)->create([
       'collection_type_id' => $this->collectionType->id,
     ]);
   }
 
-  public function testNextAlwaysUsesNewCallSequenceIfPrefixInNewStyleArray()
+  public function testNextAlwaysUsesNewCallSequenceIfPrefixInNewStyleArray() : void
   {
     $format = factory(Models\Format::class)->create();
+    $format->attachPrefixes($this->prefix->id);
 
     $sequence = Models\CallNumberSequence::next($this->collection->id, $format->id);
     $this->assertTrue(is_a($sequence,'Jitterbug\Models\NewCallNumberSequence'),
       'Sequence is not a NewCallNumberSequence, as it should be.');
   }
 
-  public function testNextReturnsNewCallNumberSequenceIfItAlreadyExists()
+  public function testNextReturnsNewCallNumberSequenceIfItAlreadyExists() : void
   {
     $callNumber = factory(Models\NewCallNumberSequence::class)->create([
       'prefix' => $this->prefix->label,
@@ -49,7 +51,7 @@ class CallNumberSequenceTest extends TestCase
       'Sequence is not a NewCallNumberSequence, as it should be.');
   }
 
-  public function testNextReturnsExistingLegacyCallNumberSequenceIfNoNewCallNumberSequenceExists()
+  public function testNextReturnsExistingLegacyCallNumberSequenceIfNoNewCallNumberSequenceExists() : void
   {
     $prefix1 = factory(Models\Prefix::class)->create([
       'label' => 'CD',
@@ -72,5 +74,13 @@ class CallNumberSequenceTest extends TestCase
       'Sequence is not a LegacyCallNumberSequence, as it should be.');
     $this->assertSame($legacyCallNumber->id, $sequence->id,
       'Sequence is not the existing legacyCallNumberSequence, as it should be.');
+  }
+
+  public function testNextRaises404ErrorForMissingPrefix() : void
+  {
+    $format = factory(Models\Format::class)->create();
+    // no prefixes have been attached to this format
+    $this->expectException(NotFoundHttpException::class);
+    Models\CallNumberSequence::next($this->collection->id, $format->id);
   }
 }

--- a/tests/Unit/CallNumberSequenceTest.php
+++ b/tests/Unit/CallNumberSequenceTest.php
@@ -25,10 +25,7 @@ class CallNumberSequenceTest extends TestCase
 
   public function testNextAlwaysUsesNewCallSequenceIfPrefixInNewStyleArray()
   {
-    $format = factory(Models\Format::class)->create([
-      # TODO APPDEV-8643 remove when column is removed
-      'prefix' => $this->prefix->label,
-    ]);
+    $format = factory(Models\Format::class)->create();
 
     $sequence = Models\CallNumberSequence::next($this->collection->id, $format->id);
     $this->assertTrue(is_a($sequence,'Jitterbug\Models\NewCallNumberSequence'),
@@ -42,10 +39,7 @@ class CallNumberSequenceTest extends TestCase
       'collection_id' => $this->collection->id,
       'next' => 2
     ]);
-    $format = factory(Models\Format::class)->create([
-      # TODO APPDEV-8643 remove when column is removed
-      'prefix' => $callNumber->prefix,
-    ]);
+    $format = factory(Models\Format::class)->create();
     $format->prefixes()->attach($this->prefix->id);
 
     $sequence = Models\CallNumberSequence::next($this->collection->id, $format->id);
@@ -70,10 +64,7 @@ class CallNumberSequenceTest extends TestCase
       'prefix' => $prefix1->label,
       'next' => 2
     ]);
-    $format = factory(Models\Format::class)->create([
-      # TODO APPDEV-8643 remove when column is removed
-      'prefix' => $prefix1->label,
-    ]);
+    $format = factory(Models\Format::class)->create();
     $format->prefixes()->attach($prefix1->id);
 
     $sequence = Models\CallNumberSequence::next($this->collection->id, $format->id);


### PR DESCRIPTION
Last summer, the prefix-format relational structure of Jitterbug was updated to be a many-to-many relationship so now is the time to remove the prefix and legacy prefix columns from formats and any related code. There is a migration to remove the columns, removal of front-end code and validations, and an adjusted scope function. Lastly, one test and one factory were edited to accommodate this change.