### PR TITLE
Change storage config based on env file

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -44,7 +44,7 @@ return [
 
 		'file' => [
 			'driver' => 'file',
-			'path'   => storage_path().'/framework/cache',
+			'path'   => env('STORAGE_CACHE_PATH',storage_path().'/framework/cache'),
 		],
 
 		'memcached' => [

--- a/config/cache.php
+++ b/config/cache.php
@@ -44,7 +44,7 @@ return [
 
 		'file' => [
 			'driver' => 'file',
-			'path'   => env('STORAGE_CACHE_PATH',storage_path().'/framework/cache'),
+			'path'   => env('STORAGE_PATH', storage_path()).'/framework/cache',
 		],
 
 		'memcached' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -45,7 +45,7 @@ return [
 
 		'local' => [
 			'driver' => 'local',
-			'root'   => env('STORAGE_PATH',storage_path().'/app'),
+			'root'   => env('STORAGE_FILE_PATH',storage_path().'/app'),
 		],
 
 		's3' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -45,7 +45,7 @@ return [
 
 		'local' => [
 			'driver' => 'local',
-			'root'   => storage_path().'/app',
+			'root'   => env('STORAGE_PATH',storage_path().'/app'),
 		],
 
 		's3' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -45,7 +45,7 @@ return [
 
 		'local' => [
 			'driver' => 'local',
-			'root'   => env('STORAGE_FILE_PATH',storage_path().'/app'),
+			'root'   => env('STORAGE_PATH', storage_path()).'/app',
 		],
 
 		's3' => [

--- a/config/session.php
+++ b/config/session.php
@@ -57,7 +57,7 @@ return [
 	|
 	*/
 
-	'files' => env('STORAGE_SESSION_PATH',storage_path().'/framework/sessions'),
+	'files' => env('STORAGE_PATH', storage_path()).'/framework/sessions',
 
 	/*
 	|--------------------------------------------------------------------------

--- a/config/session.php
+++ b/config/session.php
@@ -57,7 +57,7 @@ return [
 	|
 	*/
 
-	'files' => storage_path().'/framework/sessions',
+	'files' => env('STORAGE_SESSION_PATH',storage_path().'/framework/sessions'),
 
 	/*
 	|--------------------------------------------------------------------------

--- a/config/view.php
+++ b/config/view.php
@@ -28,6 +28,6 @@ return [
 	|
 	*/
 
-	'compiled' => realpath(storage_path().'/framework/views'),
+	'compiled' => env('STORAGE_PATH', realpath(storage_path())).'/framework/views',
 
 ];


### PR DESCRIPTION
This PR allows a storage path to be set on the server using the `.env` file variable `STORAGE_PATH`. If it's not set, it will use the local storage path.