### PR TITLE
APPDEV-10001 need to specify default values for sort direction and co…

### DIFF
--- a/app/Support/SolariumProxy.php
+++ b/app/Support/SolariumProxy.php
@@ -36,7 +36,7 @@ class SolariumProxy {
     return new Solarium\Client($config);
   }
 
-  public function query($queryParams, $start, $rows, $sortColumn, $sortDirection)
+  public function query($queryParams, $start, $rows, $sortColumn = 'updatedAt', $sortDirection = 'desc')
   {
     $solariumQuery = $this->client->createSelect();
 


### PR DESCRIPTION
…lumn in solarium proxy so resolveRange works

This small change sets a default value for `sortColumn` and `sortDirection` in the solarium proxy query function to account for when those aren't sent in.