### PR TITLE
APPDEV-10001 adding sort column and sort direction to query when tabl…

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -27,14 +27,16 @@ abstract class Controller extends BaseController {
     $queryParams = json_decode(urldecode($request->query('q')));
     $range = json_decode(urldecode($request->query('r')));
     $beginIndex = $range->beginIndex;
-    $beginId = isset($range->beginId) ? $range->beginId : null;
+    $beginId = $range->beginId ?? null;
     $endIndex = $range->endIndex;
-    $endId = isset($range->endId) ? $range->endId : null;
+    $endId = $range->endId ?? null;
     $firstIndex = min($beginIndex, $endIndex);
     $lastIndex = max($beginIndex, $endIndex);
     $start = $firstIndex;
     $rows = $lastIndex - $firstIndex + 1;
-    $resultSet = $proxy->query($queryParams,$start,$rows);
+    $sortColumn = $request->query('sortColumn');
+    $sortDirection = $request->query('sortDirection');
+    $resultSet = $proxy->query($queryParams, $start, $rows, $sortColumn, $sortDirection);
 
     $itemIds = array();
     $index = $start;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2190,9 +2190,9 @@ jitterbug = {
         // The id of the record at the index
         var id = $(this).data('id');
         // column by which table is being sorted. may be null
-        const sortColumn = $(this).data('sort-column');
+        const sortColumn = $(this).closest('table').data('sort-column');
         // direction of sort, if there is one in use
-        const sortDirection = $(this).data('sort-direction');
+        const sortDirection = $(this).closest('table').data('sort-direction');
 
         // If user is "shift-clicking" a row (i.e. selecting a range of rows)
         if (event.shiftKey) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1667,8 +1667,8 @@ jitterbug = {
         $('#header-row').click(function(e) {
           e.preventDefault();
           const column = e.target;
-          const columnName = column.getAttribute('data-name');
-          const currentSort = column.getAttribute('data-sort');
+          const columnName = column.getAttribute('data-sort-column');
+          const currentSort = column.getAttribute('data-sort-direction');
           if (columnName !== null && currentSort !== null) {
             const toggleSort = (currentSort === "asc") ? "desc" : "asc";
             tableSelection.clear();
@@ -2189,10 +2189,14 @@ jitterbug = {
         var index = $(this).data('index');
         // The id of the record at the index
         var id = $(this).data('id');
+        // column by which table is being sorted. may be null
+        const sortColumn = $(this).data('sort-column');
+        // direction of sort, if there is one in use
+        const sortDirection = $(this).data('sort-direction');
 
         // If user is "shift-clicking" a row (i.e. selecting a range of rows)
         if (event.shiftKey) {
-          resolveRange(index, id);
+          resolveRange(index, id, sortColumn, sortDirection);
           finalizeEvent(event);
           return;
         }
@@ -2259,7 +2263,7 @@ jitterbug = {
     },
 
     // Resolve a range selection to an array of ids
-    resolveRange = function(endIndex, endId) {
+    resolveRange = function(endIndex, endId, sortColumn, sortDirection) {
       if (beginIndex == null && beginId == null) {
         beginIndex = endIndex;
         beginId = endId;
@@ -2284,6 +2288,8 @@ jitterbug = {
             var range = JSON.stringify({beginIndex: beginIndex, 
               beginId: beginId, endIndex: endIndex, endId: endId});
             query['r'] = encodeURIComponent(range);
+            query['sortColumn'] = sortColumn;
+            query['sortDirection'] = sortDirection;
 
             $.ajax({
               url: '/' + resource + '/resolve-range',

--- a/resources/views/items/_items.blade.php
+++ b/resources/views/items/_items.blade.php
@@ -1,6 +1,6 @@
 <div id="data-container">
   {{-- The ID of this table needs to be unique across Jitterbug (i.e. different than the data table in masters or transfers) so that the colResizable plugin stores and loads unique column widths (set by the user) to localStorage. --}}
-  <table id="items-data" class="table table-sm table-hover">
+  <table id="items-data" class="table table-sm table-hover" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
     <thead>
       <tr id="header-row" role="rowheader">
         {{-- data name is camelCase for solr query purposes, see SolariumProxy--}}
@@ -21,7 +21,7 @@
     <tbody>
       <?php $index = 0; ?>
       @foreach ($items as $item)
-      <tr role="button" class="@if ($marks->contains($item->id)) marked @endif" data-id="{{ $item->id }}" data-index="{{ $start + $index }}" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
+      <tr role="button" class="@if ($marks->contains($item->id)) marked @endif" data-id="{{ $item->id }}" data-index="{{ $start + $index }}">
         <td>{{ $item->callNumber }}</td>
         <td title="{{ $item->title }}">{{ $item->title }}</td>
         <td title="{{ $item->containerNote }}">{{ $item->containerNote }}</td>

--- a/resources/views/items/_items.blade.php
+++ b/resources/views/items/_items.blade.php
@@ -4,13 +4,13 @@
     <thead>
       <tr id="header-row" role="rowheader">
         {{-- data name is camelCase for solr query purposes, see SolariumProxy--}}
-        <th data-sort="{{$sortColumn === 'callNumber' ? $sortDirection : 'asc'}}" data-name="callNumber">
+        <th data-sort-direction="{{$sortColumn === 'callNumber' ? $sortDirection : 'asc'}}" data-sort-column="callNumber">
           Call #&nbsp;<span class="fa fa-sort"></span>
         </th>
-        <th data-sort="{{$sortColumn === 'title' ? $sortDirection : 'asc'}}" data-name="title">
+        <th data-sort-direction="{{$sortColumn === 'title' ? $sortDirection : 'asc'}}" data-sort-column="title">
           Title&nbsp;<span class="fa fa-sort"></span>
         </th>
-        <th data-sort="{{$sortColumn === 'containerNote' ? $sortDirection : 'asc'}}" data-name="containerNote">
+        <th data-sort-direction="{{$sortColumn === 'containerNote' ? $sortDirection : 'asc'}}" data-sort-column="containerNote">
           Container Note&nbsp;<span class="fa fa-sort"></span>
         </th>
         <th>Collection</th>
@@ -21,7 +21,7 @@
     <tbody>
       <?php $index = 0; ?>
       @foreach ($items as $item)
-      <tr role="button" class="@if ($marks->contains($item->id)) marked @endif" data-id="{{ $item->id }}" data-index="{{ $start + $index }}">
+      <tr role="button" class="@if ($marks->contains($item->id)) marked @endif" data-id="{{ $item->id }}" data-index="{{ $start + $index }}" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
         <td>{{ $item->callNumber }}</td>
         <td title="{{ $item->title }}">{{ $item->title }}</td>
         <td title="{{ $item->containerNote }}">{{ $item->containerNote }}</td>

--- a/resources/views/masters/_masters.blade.php
+++ b/resources/views/masters/_masters.blade.php
@@ -2,7 +2,7 @@
   <table id="masters-data" class="table table-sm table-hover">
     <thead>
       <tr id="header-row">
-        <th data-sort="{{$sortColumn === 'callNumber' ? $sortDirection : 'asc'}}" data-name="callNumber">
+        <th data-sort-direction="{{$sortColumn === 'callNumber' ? $sortDirection : 'asc'}}" data-sort-column="callNumber">
           Call Number&nbsp;<span class="fa fa-sort"></span>
         </th>
         <th>File Name</th>
@@ -15,7 +15,7 @@
     <tbody>
       <?php $index = 0; ?>
       @foreach ($masters as $master)
-      <tr role="button" class="@if ($marks->contains($master->id)) marked @endif" data-id="{{ $master->id }}" data-index="{{ $start + $index }}">
+      <tr role="button" class="@if ($marks->contains($master->id)) marked @endif" data-id="{{ $master->id }}" data-index="{{ $start + $index }}" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
         <td>{{ $master->callNumber }}</td>
         <td>{{ $master->fileName }}</td>
         <td title="{{ $master->collectionName}}">{{ $master->collectionName }}</td>

--- a/resources/views/masters/_masters.blade.php
+++ b/resources/views/masters/_masters.blade.php
@@ -1,5 +1,5 @@
 <div id="data-container">
-  <table id="masters-data" class="table table-sm table-hover">
+  <table id="masters-data" class="table table-sm table-hover" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
     <thead>
       <tr id="header-row">
         <th data-sort-direction="{{$sortColumn === 'callNumber' ? $sortDirection : 'asc'}}" data-sort-column="callNumber">
@@ -15,7 +15,7 @@
     <tbody>
       <?php $index = 0; ?>
       @foreach ($masters as $master)
-      <tr role="button" class="@if ($marks->contains($master->id)) marked @endif" data-id="{{ $master->id }}" data-index="{{ $start + $index }}" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
+      <tr role="button" class="@if ($marks->contains($master->id)) marked @endif" data-id="{{ $master->id }}" data-index="{{ $start + $index }}">
         <td>{{ $master->callNumber }}</td>
         <td>{{ $master->fileName }}</td>
         <td title="{{ $master->collectionName}}">{{ $master->collectionName }}</td>

--- a/resources/views/transfers/_transfers.blade.php
+++ b/resources/views/transfers/_transfers.blade.php
@@ -1,8 +1,8 @@
 <div id="data-container">
-  <table id="transfers-data" class="table table-sm table-hover">
+  <table id="transfers-data" class="table table-sm table-hover" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
     <thead>
       <tr id="header-row">
-        <th data-sort="{{$sortColumn === 'callNumber' ? $sortDirection : 'asc'}}" data-name="callNumber">
+        <th data-sort-direction="{{$sortColumn === 'callNumber' ? $sortDirection : 'asc'}}" data-sort-column="callNumber">
           Call Number&nbsp;<span class="fa fa-sort"></span>
         </th>
         <th>Date</th>
@@ -18,7 +18,7 @@
     <tbody>
       <?php $index = 0; ?>
       @foreach ($transfers as $transfer)
-      <tr role="button" class="@if ($marks->contains($transfer->id)) marked @endif" data-id="{{ $transfer->id }}" data-index="{{ $start + $index }}" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
+      <tr role="button" class="@if ($marks->contains($transfer->id)) marked @endif" data-id="{{ $transfer->id }}" data-index="{{ $start + $index }}">
         <td>{{ $transfer->callNumber }}</td>
         <td>{{ $transfer->transferDate }}</td>
         <td @if ($transfer->engineerName) title="{{ $transfer->engineerFirstName }} {{ $transfer->engineerLastName }}" @endif>{{ $transfer->engineerFirstName }} {{ $transfer->engineerLastName }}</td>

--- a/resources/views/transfers/_transfers.blade.php
+++ b/resources/views/transfers/_transfers.blade.php
@@ -6,7 +6,7 @@
           Call Number&nbsp;<span class="fa fa-sort"></span>
         </th>
         <th>Date</th>
-        <th data-sort="{{$sortColumn === 'engineerLastName' ? $sortDirection : 'asc'}}" data-name="engineerLastName">
+        <th data-sort-direction="{{$sortColumn === 'engineerLastName' ? $sortDirection : 'asc'}}" data-sort-column="engineerLastName">
           Engineer&nbsp;<span class="fa fa-sort"></span>
         </th>
         <th>Vendor</th>
@@ -18,7 +18,7 @@
     <tbody>
       <?php $index = 0; ?>
       @foreach ($transfers as $transfer)
-      <tr role="button" class="@if ($marks->contains($transfer->id)) marked @endif" data-id="{{ $transfer->id }}" data-index="{{ $start + $index }}">
+      <tr role="button" class="@if ($marks->contains($transfer->id)) marked @endif" data-id="{{ $transfer->id }}" data-index="{{ $start + $index }}" data-sort-column="{{$sortColumn}}" data-sort-direction="{{$sortDirection}}">
         <td>{{ $transfer->callNumber }}</td>
         <td>{{ $transfer->transferDate }}</td>
         <td @if ($transfer->engineerName) title="{{ $transfer->engineerFirstName }} {{ $transfer->engineerLastName }}" @endif>{{ $transfer->engineerFirstName }} {{ $transfer->engineerLastName }}</td>


### PR DESCRIPTION
…e rows are selected via keyboard shortcuts

This PR solves the problem of trying to select multiple rows across multiple pages when there is a sort in use. Previously, if a sort was used, the `resolveRange` function was failing because when comparing included IDs to a query sent to solr, without the sort included it might not include the specific ID. To make the solr query more accurate, it needs to have the sort column and sort direction included.

Since I added new data attributes to the rows, I also decided to make the data attribute naming clearer and more consistent.