### PR TITLE
Appdev 9994 solr config change for sorting

### DIFF
--- a/app/Support/SolariumProxy.php
+++ b/app/Support/SolariumProxy.php
@@ -66,6 +66,12 @@ class SolariumProxy {
 
     $this->createFilterQueries($solariumQuery,$queryParams);
 
+    // use Sortable version of solr field if it's not the default updatedAt field
+    // ex. callNumber => callNumberSortable
+    if ($sortColumn !== 'updatedAt') {
+      $sortColumn .= 'Sortable';
+    }
+
     $solariumQuery->setStart($start);
     $solariumQuery->setRows($rows);
     $solariumQuery->addSort($sortColumn, $sortDirection);

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Jitterbug\Models\User;
+use Illuminate\Support\Facades\Hash;
 
 class UsersTableSeeder extends Seeder
 {
@@ -13,7 +14,7 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
-        if(env('APP_ENV') != 'production')
+        if(env('APP_ENV') !== 'production')
         {
           $password = Hash::make(env('ADMIN_USER_PASSWORD'));
           $users[] = [

--- a/solrconfig/jitterbug-items/conf/managed-schema
+++ b/solrconfig/jitterbug-items/conf/managed-schema
@@ -114,11 +114,11 @@
 
    <!-- Jitterbug specific fields -->
    <field name="callNumber" type="text_general" indexed="true" stored="true" required="false" />
-   <field name="callNumberSortable" type="lowercase" indexed="true" stored="true" required="false" />
+   <field name="callNumberSortable" type="lowercase" indexed="true" stored="false" required="false" />
    <field name="title" type="text_general" indexed="true" stored="true" required="false" />
-   <field name="titleSortable" type="lowercase" indexed="true" stored="true" required="false" />
+   <field name="titleSortable" type="lowercase" indexed="true" stored="false" required="false" />
    <field name="containerNote" type="text_general" indexed="true" stored="true" required="false" />
-   <field name="containerNoteSortable" type="lowercase" indexed="true" stored="true" required="false" />
+   <field name="containerNoteSortable" type="lowercase" indexed="true" stored="false" required="false" />
    <field name="recordingLocation" type="text_general" indexed="true" stored="true" required="false" />
    <field name="itemDate" type="date" indexed="true" stored="true" required="false" />
    <field name="accessionNumber" type="string" indexed="true" stored="true" required="false" />

--- a/solrconfig/jitterbug-items/conf/managed-schema
+++ b/solrconfig/jitterbug-items/conf/managed-schema
@@ -114,8 +114,11 @@
 
    <!-- Jitterbug specific fields -->
    <field name="callNumber" type="text_general" indexed="true" stored="true" required="false" />
+   <field name="callNumberSortable" type="lowercase" indexed="true" stored="true" required="false" />
    <field name="title" type="text_general" indexed="true" stored="true" required="false" />
+   <field name="titleSortable" type="lowercase" indexed="true" stored="true" required="false" />
    <field name="containerNote" type="text_general" indexed="true" stored="true" required="false" />
+   <field name="containerNoteSortable" type="lowercase" indexed="true" stored="true" required="false" />
    <field name="recordingLocation" type="text_general" indexed="true" stored="true" required="false" />
    <field name="itemDate" type="date" indexed="true" stored="true" required="false" />
    <field name="accessionNumber" type="string" indexed="true" stored="true" required="false" />
@@ -192,10 +195,9 @@
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->
 
-  <!--
-   <copyField source="title" dest="text"/>
-   <copyField source="body" dest="text"/>
-  -->
+   <copyField source="callNumber" dest="callNumberSortable"/>
+   <copyField source="title" dest="titleSortable"/>
+   <copyField source="containerNote" dest="containerNoteSortable"/>
   
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"

--- a/solrconfig/jitterbug-masters/conf/managed-schema
+++ b/solrconfig/jitterbug-masters/conf/managed-schema
@@ -114,7 +114,7 @@
 
    <!-- Jitterbug specific fields -->
    <field name="callNumber" type="text_general" indexed="true" stored="true" required="false" />
-   <field name="callNumberSortable" type="lowercase" indexed="true" stored="true" required="false" />
+   <field name="callNumberSortable" type="lowercase" indexed="true" stored="false" required="false" />
    <field name="fileName" type="text_general" indexed="true" stored="true" required="false" />
    <field name="durationInSeconds" type="string" indexed="false" stored="true" required="false" />
    <field name="departmentId" type="string" indexed="true" stored="true" required="false" />

--- a/solrconfig/jitterbug-masters/conf/managed-schema
+++ b/solrconfig/jitterbug-masters/conf/managed-schema
@@ -114,6 +114,7 @@
 
    <!-- Jitterbug specific fields -->
    <field name="callNumber" type="text_general" indexed="true" stored="true" required="false" />
+   <field name="callNumberSortable" type="lowercase" indexed="true" stored="true" required="false" />
    <field name="fileName" type="text_general" indexed="true" stored="true" required="false" />
    <field name="durationInSeconds" type="string" indexed="false" stored="true" required="false" />
    <field name="departmentId" type="string" indexed="true" stored="true" required="false" />
@@ -191,10 +192,7 @@
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->
 
-  <!--
-   <copyField source="title" dest="text"/>
-   <copyField source="body" dest="text"/>
-  -->
+   <copyField source="callNumber" dest="callNumberSortable"/>
   
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"

--- a/solrconfig/jitterbug-transfers/conf/managed-schema
+++ b/solrconfig/jitterbug-transfers/conf/managed-schema
@@ -114,7 +114,7 @@
 
    <!-- Jitterbug specific fields -->
    <field name="callNumber" type="text_general" indexed="true" stored="true" required="false" />
-   <field name="callNumberSortable" type="lowercase" indexed="true" stored="true" required="false" />
+   <field name="callNumberSortable" type="lowercase" indexed="true" stored="false" required="false" />
    <field name="transferDate" type="string" indexed="true" stored="true" required="false" />
    <field name="preservationMasterId" type="string" indexed="true" stored="true" required="false" />
    <field name="vendorId" type="string" indexed="true" stored="true" required="false" />
@@ -122,6 +122,7 @@
    <field name="engineerId" type="string" indexed="true" stored="true" required="false" />
    <field name="engineerFirstName" type="text_general" indexed="true" stored="true" required="false" />
    <field name="engineerLastName" type="text_general" indexed="true" stored="true" required="false" />
+   <field name="engineerLastNameSortable" type="lowercase" indexed="true" stored="false" required="false" />
    <field name="collectionId" type="string" indexed="true" stored="true" required="false" />
    <field name="collectionName" type="text_general" indexed="true" stored="true" required="false" />
    <field name="formatId" type="string" indexed="true" stored="true" required="false" />
@@ -193,6 +194,7 @@
         or to add multiple fields to the same field for easier/faster searching.  -->
 
    <copyField source="callNumber" dest="callNumberSortable"/>
+   <copyField source="engineerLastName" dest="engineerLastNameSortable"/>
   
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"

--- a/solrconfig/jitterbug-transfers/conf/managed-schema
+++ b/solrconfig/jitterbug-transfers/conf/managed-schema
@@ -114,6 +114,7 @@
 
    <!-- Jitterbug specific fields -->
    <field name="callNumber" type="text_general" indexed="true" stored="true" required="false" />
+   <field name="callNumberSortable" type="lowercase" indexed="true" stored="true" required="false" />
    <field name="transferDate" type="string" indexed="true" stored="true" required="false" />
    <field name="preservationMasterId" type="string" indexed="true" stored="true" required="false" />
    <field name="vendorId" type="string" indexed="true" stored="true" required="false" />
@@ -191,10 +192,7 @@
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->
 
-  <!--
-   <copyField source="title" dest="text"/>
-   <copyField source="body" dest="text"/>
-  -->
+   <copyField source="callNumber" dest="callNumberSortable"/>
   
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"


### PR DESCRIPTION
After the sorting functionality was released, users noticed that sorting of titles and notes were not as alphabetical as they expected. It turns out that the field used in solr for these columns were great for searching (every word is tokenized) but not for sorting.

This PR introduces new solr fields that use the "lowercase" field type so that when sorted by these fields, results show up in a more logical manner for that sort.

Also includes a small edit to a seeder that was noticed after repopulating the VM DB.