### PR TITLE
Appdev 10000 preservation instance

### DIFF
--- a/database/factories/PreservationInstanceFactory.php
+++ b/database/factories/PreservationInstanceFactory.php
@@ -38,7 +38,7 @@ class PreservationInstanceFactory extends Factory
           'file_format' => $this->faker->word,
           'file_codec' => $this->faker->word,
           'access_file_location' => $this->faker->word,
-          'subclass_type' => $this->faker->word,
+          'subclass_type' => 'AudioInstance',
           'subclass_id' => $this->faker->randomNumber(),
         ];
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -124,17 +124,17 @@ Route::get('cuts/{id}', 'CutsController@get');
 */
 
 Route::get('instance/resolve-range', 'InstancesController@resolveRange');
-Route::match(['post', 'get'], 'instance/batch/edit',
+Route::match(['post', 'get'], 'instances/batch/edit',
   'InstancesController@batchEdit')->name('instances.batch.edit');
-Route::put('instance/batch',
+Route::put('instances/batch',
   'InstancesController@batchUpdate')->name('instances.batch.update');
-Route::delete('instance/batch',
+Route::delete('instances/batch',
   'InstancesController@batchDestroy')->name('instances.batch.destroy');
-Route::post('instance/batch/export-fields',
+Route::post('instances/batch/export-fields',
   'InstancesController@batchExportFields')->name('instances.batch.export.fields');
-Route::post('instance/batch/export-build',
+Route::post('instances/batch/export-build',
   'InstancesController@batchExportBuild')->name('instances.batch.export.build');
-Route::post('instance/batch/export-download',
+Route::post('instances/batch/export-download',
   'InstancesController@batchExportDownload')->name('instances.batch.export.download');
 Route::resource('instances', 'InstancesController');
 Route::resource('instance.cuts', 'CutsController', ['except' => ['index']]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -123,7 +123,7 @@ Route::get('cuts/{id}', 'CutsController@get');
 |--------------------------------------------------------------------------
 */
 
-Route::get('instance/resolve-range', 'InstancesController@resolveRange');
+Route::get('instances/resolve-range', 'InstancesController@resolveRange');
 Route::match(['post', 'get'], 'instances/batch/edit',
   'InstancesController@batchEdit')->name('instances.batch.edit');
 Route::put('instances/batch',

--- a/tests/Browser/SelectAllTest.php
+++ b/tests/Browser/SelectAllTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Browser;
+
+use Facebook\WebDriver\WebDriverKeys;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Jitterbug\Models\User;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class SelectAllTest extends DuskTestCase
+{
+  use DatabaseMigrations;
+    /**
+     * A Dusk test example.
+     *
+     * @return void
+     */
+  public function testSelectAllWorks()
+  {
+    User::factory()->create();
+    $this->browse(function (Browser $browser) {
+      $browser->loginAs(User::find(1))
+        ->visit('/instances')
+        ->keys('#search', 'general', '{enter}')
+        ->pause(1000)
+        ->click('table > thead > tr > th')
+        ->driver->getKeyboard()->sendKeys([WebDriverKeys::COMMAND, 'a']);
+
+      $browser->pause(10000)->assertPresent('.selected');
+    });
+  }
+}


### PR DESCRIPTION
This PR fixes bugs that Erica identified:
- Batch editing in Preservation Instances leads to Error page
- Batch export in Preservation Instances leads to empty window 
- Issue of Control+A and Control+Select not working across multiple pages in table

It also adds a browser test for the select all functionality, as this is the third time that's had to be fixed.