### PR TITLE
APPDEV-10091 fixing hopefully the last instances-related routing problem

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -137,7 +137,7 @@ Route::post('instances/batch/export-build',
 Route::post('instances/batch/export-download',
   'InstancesController@batchExportDownload')->name('instances.batch.export.download');
 Route::resource('instances', 'InstancesController');
-Route::resource('instance.cuts', 'CutsController', ['except' => ['index']]);
+Route::resource('instances.cuts', 'CutsController', ['except' => ['index']]);
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
There was one last place in the preservation instances routing config that should have been plural instead of singular. This PR fixes that, and therefore also fixes the 500 error encountered in https://jira.lib.unc.edu/browse/APPDEV-10091