### PR TITLE
Appdev 6818 pi designated av items

### DIFF
--- a/app/Http/Controllers/InstancesController.php
+++ b/app/Http/Controllers/InstancesController.php
@@ -195,6 +195,15 @@ class InstancesController extends Controller {
 
     // Update Solr
     $this->solrInstances->update($instances);
+    // we track which AV items have preservation instances
+    // so for each created preservation instance, the related item should be updated
+    foreach ($instances as $instance) {
+      $item =
+        AudioVisualItem::where('call_number', $instance->call_number)->first();
+      if ($item !== null) {
+        $this->solrItems->update($item);
+      }
+    }
 
     if ($batch) {
       $request->session()->put('alert', array('type' => 'success', 'message' => 

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -28,6 +28,7 @@ class AudioImport extends Import {
   protected $audioImportKeys = array();
   protected $mustAlreadyExistInDbKeys = array();
 
+  protected $solrItems;
   protected $solrInstances;
   protected $solrTransfers;
 
@@ -47,6 +48,7 @@ class AudioImport extends Import {
       'Speed' => AudioVisualItem::class
     );
 
+    $this->solrItems = new SolariumProxy('jitterbug-items');
     $this->solrInstances = new SolariumProxy('jitterbug-instances');
     $this->solrTransfers = new SolariumProxy('jitterbug-transfers');
 
@@ -158,6 +160,7 @@ class AudioImport extends Import {
   public function execute()
   {
     // Keep track of which instances and transfers to update in Solr
+    $items = array();
     $instances = array();
     $transfers = array();
     $created = $updated = 0;
@@ -362,6 +365,10 @@ class AudioImport extends Import {
           }
         }
 
+        // collect related AV item in array for solr update
+        $item = AudioVisualItem::where('call_number', $callNumber)->first();
+        $items[] = $item;
+
       } // end foreach row
       // if nothing was created and records were updated, the import is an update
       if (empty($created) && !empty($updated)) {
@@ -371,6 +378,7 @@ class AudioImport extends Import {
       DB::statement('set @transaction_id = null;');      
     });
 
+    $this->solrItems->update($items);
     $this->solrInstances->update($instances);
     $this->solrTransfers->update($transfers);
 

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -167,7 +167,7 @@ class AudioImport extends Import {
 
     // Update MySQL
     DB::transaction( function () 
-      use (&$instances, &$transfers, &$created, &$updated) {
+      use (&$items, &$instances, &$transfers, &$created, &$updated) {
       $transactionId = Uuid::uuid4();
       DB::statement("set @transaction_id = '$transactionId';");
 
@@ -367,8 +367,6 @@ class AudioImport extends Import {
 
         // collect related AV item in array for solr update
         $item = AudioVisualItem::where('call_number', $callNumber)->first();
-        $item->touch();
-        $item->save();
         $items[] = $item;
 
       } // end foreach row

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -367,6 +367,8 @@ class AudioImport extends Import {
 
         // collect related AV item in array for solr update
         $item = AudioVisualItem::where('call_number', $callNumber)->first();
+        $item->touch();
+        $item->save();
         $items[] = $item;
 
       } // end foreach row

--- a/app/Import/VideoImport.php
+++ b/app/Import/VideoImport.php
@@ -263,12 +263,9 @@ class VideoImport extends Import {
         $videoItem->save();
         $updated++;
 
-        // Touch the audio visual item
+        // collect related AV item in array for solr update
         $item = AudioVisualItem::where('call_number', $callNumber)->first();
-        $item->touch();
-        $item->save();
         $items[] = $item;
-        $updated++;
 
       } // end foreach row
 

--- a/app/Import/VideoImport.php
+++ b/app/Import/VideoImport.php
@@ -265,6 +265,8 @@ class VideoImport extends Import {
 
         // collect related AV item in array for solr update
         $item = AudioVisualItem::where('call_number', $callNumber)->first();
+        $item->touch();
+        $item->save();
         $items[] = $item;
 
       } // end foreach row

--- a/app/Import/VideoImport.php
+++ b/app/Import/VideoImport.php
@@ -265,8 +265,6 @@ class VideoImport extends Import {
 
         // collect related AV item in array for solr update
         $item = AudioVisualItem::where('call_number', $callNumber)->first();
-        $item->touch();
-        $item->save();
         $items[] = $item;
 
       } // end foreach row

--- a/app/Support/SolariumProxy.php
+++ b/app/Support/SolariumProxy.php
@@ -325,7 +325,7 @@ class SolariumProxy {
       $cutPerformerComposers, null, 'set');
   }
 
-  protected function createFilterQueries($solariumQuery, $queryParams)
+  protected function createFilterQueries($solariumQuery, $queryParams) : void
   {
     $keys = array_keys((array)($queryParams));
     foreach ($keys as $key) {
@@ -333,7 +333,11 @@ class SolariumProxy {
         $filters = $queryParams->{$key};
         if($this->hasFilters($filters)) {
           $filterType = $this->filterType($key);
-          $filterQuery = $this->filterQueryFor($filterType . 'Id', $filters);
+          if ($filterType === 'preservation-instance') {
+            $filterQuery = 'preservationInstanceExists:' . $filters[0];
+          } else {
+            $filterQuery = $this->filterQueryFor($filterType . 'Id', $filters);
+          }
           $solariumQuery->
             createFilterQuery($filterType . 's')->setQuery($filterQuery);
         }
@@ -341,9 +345,10 @@ class SolariumProxy {
     }
   }
 
-  protected function hasFilters($filterArray)
+  protected function hasFilters($filterArray) : bool
   {
-    return $filterArray[0] != 0;
+    // '0' is the value for the "any" option in the filters
+    return $filterArray[0] !== '0';
   }
   
   protected function filterType($filterKey)
@@ -351,7 +356,7 @@ class SolariumProxy {
     return substr($filterKey,0,strlen($filterKey) - strlen('-filters'));
   }
 
-  protected function filterQueryFor($field, $filters)
+  protected function filterQueryFor($field, $filters) : string
   {
     $filterQuery = $field . ':(';
     $numFilters = count($filters);

--- a/app/Support/SolariumProxy.php
+++ b/app/Support/SolariumProxy.php
@@ -149,6 +149,7 @@ class SolariumProxy {
     $doc->setField('accessionNumber', $item->accession_number, null, 'set');
     $doc->setField('typeName', $item->type, null, 'set');
     $doc->setField('typeId', $item->type_id, null, 'set');
+    $doc->setField('preservationInstanceExists', $item->preservationInstances()->exists(), null, 'set');
     $doc->setField('createdAt', $item->created_at, null, 'set');
     $doc->setField('updatedAt', $item->updated_at, null, 'set');
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2066,9 +2066,8 @@ jitterbug = {
       if (totalChecked != selectedFilters.length) {
         setDefault();
       }
-
+      // radio button should be checked if its value is in the selectedFilters array
       $.each(radioButtons, function(i, radioButton) {
-        // radio button should be checked if its value is in the selectedFilters array
         radioButton.checked = $.inArray(radioButton.value, selectedFilters) !== -1;
       });
       renderSelectionCount();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2001,6 +2001,7 @@ jitterbug = {
   FilterList: function(listElement) {
     var list = listElement,
         checkboxes = $(list).find(':checkbox'),
+        radioButtons = $(list).find(':radio'),
     
     init = function() {
       $.each(checkboxes, function(i, checkbox) {
@@ -2041,12 +2042,18 @@ jitterbug = {
           $.publish('filterChanged');
         });
       });
+      $.each(radioButtons, function(i, radioButton) {
+        $(radioButton).click(function(event) {
+          $.publish('filterChanged');
+        });
+      });
     },
 
     setSelected = function(selectedFilters) {
       var totalChecked = 0;
       $.each(checkboxes, function(i, checkbox) {
-        if ($.inArray(checkbox.value, selectedFilters) != -1) {
+        // if the checkbox value is found in the selectedFilters array
+        if ($.inArray(checkbox.value, selectedFilters) !== -1) {
           checkbox.checked = true;
           totalChecked++;
         } else {
@@ -2059,6 +2066,11 @@ jitterbug = {
       if (totalChecked != selectedFilters.length) {
         setDefault();
       }
+
+      $.each(radioButtons, function(i, radioButton) {
+        // radio button should be checked if its value is in the selectedFilters array
+        radioButton.checked = $.inArray(radioButton.value, selectedFilters) !== -1;
+      });
       renderSelectionCount();
     },
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2074,13 +2074,18 @@ jitterbug = {
     },
 
     setDefault = function() {
-      $.each(checkboxes, function(i, value) {
+      $.each(checkboxes, function(i) {
         if (i == 0) {
           checkboxes[i].checked = true;
         } else {
           checkboxes[i].checked = false;
         }
       });
+      // check first if there are any radio buttons on the page
+      // then check first radio button, which is the 'any'
+      if (radioButtons.length) {
+        radioButtons[0].checked = true;
+      }
     },
 
     listType = function() {

--- a/resources/views/items/_preservation_instance_filter.blade.php
+++ b/resources/views/items/_preservation_instance_filter.blade.php
@@ -1,0 +1,27 @@
+<h6>Preservation Instance Filter<span class="selection-count label label-default" style="margin-left: 5px;"></span></h6>
+<ul id="preservation-instance-filters" class="filter-list">
+  <li>
+    <div>
+      <label>
+        <input type="radio" name="pi_exists" value="0">
+        Any
+      </label>
+    </div>
+  </li>
+  <li>
+    <div>
+      <label>
+        <input type="radio" name="pi_exists" value="true">
+        Digitized
+      </label>
+    </div>
+  </li>
+  <li>
+    <div>
+      <label>
+        <input type="radio" name="pi_exists" value="false">
+        Not Digitized
+      </label>
+    </div>
+  </li>
+</ul>

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -3,33 +3,7 @@
 @section('content')
 <div class="row">
   <div id="filter-panel" class="col-xs-3 panel">
-    <h6>Preservation Instance Filter<span class="selection-count label label-default" style="margin-left: 5px;"></span></h6>
-    <ul id="preservation-instance-filters" class="filter-list">
-      <li>
-        <div>
-          <label>
-            <input type="radio" name="pi_exists" value="0">
-            Any
-          </label>
-        </div>
-      </li>
-      <li>
-        <div>
-          <label>
-            <input type="radio" name="pi_exists" value="true">
-            Digitized
-          </label>
-        </div>
-      </li>
-      <li>
-        <div>
-          <label>
-            <input type="radio" name="pi_exists" value="false">
-            Not Digitized
-          </label>
-        </div>
-      </li>
-    </ul>
+    @include('items._preservation_instance_filter')
     @include('shared._filter-list', ['name' => 'type', 'filters' => $types])
     @include('shared._filter-list', ['name' => 'collection', 'filters' => $collections, 'style' => 'height: 188px;'])
     @include('shared._filter-list', ['name' => 'format', 'filters' => $formats, 'style' => 'height: 150px;'])

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -3,9 +3,36 @@
 @section('content')
 <div class="row">
   <div id="filter-panel" class="col-xs-3 panel">
+    <h6>Preservation Instance Filter<span class="selection-count label label-default" style="margin-left: 5px;"></span></h6>
+    <ul id="preservation-instance-filters" class="filter-list">
+      <li>
+        <div>
+          <label>
+            <input type="radio" name="pi_exists" value="0">
+            Any
+          </label>
+        </div>
+      </li>
+      <li>
+        <div>
+          <label>
+            <input type="radio" name="pi_exists" value="true">
+            Digitized
+          </label>
+        </div>
+      </li>
+      <li>
+        <div>
+          <label>
+            <input type="radio" name="pi_exists" value="false">
+            Not Digitized
+          </label>
+        </div>
+      </li>
+    </ul>
     @include('shared._filter-list', ['name' => 'type', 'filters' => $types])
-    @include('shared._filter-list', ['name' => 'collection', 'filters' => $collections, 'style' => 'height: 268px;'])
-    @include('shared._filter-list', ['name' => 'format', 'filters' => $formats, 'style' => 'height: 250px;'])
+    @include('shared._filter-list', ['name' => 'collection', 'filters' => $collections, 'style' => 'height: 188px;'])
+    @include('shared._filter-list', ['name' => 'format', 'filters' => $formats, 'style' => 'height: 150px;'])
   </div>
   <div id="data-panel" class="col-xs-9 panel">
     <div class="top-controls">

--- a/solrconfig/jitterbug-items/conf/managed-schema
+++ b/solrconfig/jitterbug-items/conf/managed-schema
@@ -135,6 +135,7 @@
    <field name="cutIds" type="string" indexed="false" stored="true" required="false" multiValued="true" />
    <field name="cutPerformerComposers" type="text_general" indexed="true" stored="true" required="false" multiValued="true" />
    <field name="cutTitles" type="text_general" indexed="true" stored="true" required="false" multiValued="true" />
+   <field name="preservationInstanceExists" type="boolean" indexed="true" stored="true" required="false" />
 
 
    <!-- Dynamic field definitions allow using convention over configuration

--- a/solrconfig/jitterbug-items/conf/solr-data-config.xml
+++ b/solrconfig/jitterbug-items/conf/solr-data-config.xml
@@ -23,7 +23,7 @@
                 collections.name AS collection_name,
                 formats.name AS format_name,
                 TRIM(TRAILING 'Item' FROM items.subclass_type) AS type_name,
-                CASE WHEN preservation_instances.call_number IS NOT NULL THEN TRUE ELSE FALSE as preservation_instance_exists
+                CASE WHEN preservation_instances.call_number IS NOT NULL THEN TRUE ELSE FALSE END as preservation_instance_exists
             FROM
                 audio_visual_items AS items
             LEFT JOIN film_items ON

--- a/solrconfig/jitterbug-items/conf/solr-data-config.xml
+++ b/solrconfig/jitterbug-items/conf/solr-data-config.xml
@@ -22,7 +22,8 @@
                 types.id AS type_id,
                 collections.name AS collection_name,
                 formats.name AS format_name,
-                TRIM(TRAILING 'Item' FROM items.subclass_type) AS type_name
+                TRIM(TRAILING 'Item' FROM items.subclass_type) AS type_name,
+                CASE WHEN preservation_instances.call_number IS NOT NULL THEN TRUE ELSE FALSE as preservation_instance_exists
             FROM
                 audio_visual_items AS items
             LEFT JOIN film_items ON
@@ -37,6 +38,8 @@
                 items.format_id = formats.id
             LEFT JOIN media_types AS types ON
                 TRIM(TRAILING 'Item' FROM items.subclass_type) = types.name
+            LEFT JOIN preservation_instances ON
+                items.call_number = preservation_instances.call_number
             WHERE
                 items.deleted_at is null;
 
@@ -57,6 +60,7 @@
             <field column="type_name" name="typeName" />
             <field column="film_element" name="filmElement" />
             <field column="video_element" name="videoElement" />
+            <field column="preservation_instance_exists" name="preservationInstanceExists" />
             <field column="created_at" name="createdAt" />
             <field column="updated_at" name="updatedAt" />
 


### PR DESCRIPTION
This PR introduces a new filter for the AV Items index: the preservation instances filter. If an AV Item has a related preservation instance, that means it has been digitized, so this new filter allows the user to see which items have been digitized and which have not. It works in concert with the other filters, the search bar, and the pagination.

![Screen Shot 2021-06-29 at 3 45 22 PM](https://user-images.githubusercontent.com/6546457/123858147-2c7c6580-d8f1-11eb-916a-33c6f91735c2.png)
