### PR TITLE
Appdev 8654 import columns optional

### DIFF
--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -217,7 +217,7 @@ class AudioImport extends Import {
 
         // Original PM is optional, so the column may not be present in the file
         $originalPm = $row['OriginalPm'] ?? null;
-        $duration = DurationFormat::toSeconds($row['Duration']);
+        $duration = isset($row['Duration']) ? DurationFormat::toSeconds($row['Duration']) : null;
         
         if (!empty($originalPm)) { 
           // Original PM not empty so this is an update

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -186,7 +186,7 @@ class AudioImport extends Import {
       $departmentCache = array();
 
       foreach($this->data as $row) {
-        // call number is allowed to be null if it's an update
+        // call number has been validated to see if it's allowed to be null
         $callNumber = $row['CallNumber'] ?? null;
 
         // We need to lookup the playback machine record to get the 

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -27,6 +27,7 @@ class AudioImport extends Import {
   protected $requiredAudioImportKeys = array();
   protected $audioImportKeys = array();
   protected $mustAlreadyExistInDbKeys = array();
+  protected $avItemFieldKeys = array();
 
   protected $solrItems;
   protected $solrInstances;
@@ -47,6 +48,7 @@ class AudioImport extends Import {
       'Base' => AudioItem::class,
       'Speed' => AudioVisualItem::class
     );
+    $this->avItemFieldKeys = array('Size', 'TrackConfiguration', 'Base', 'Speed');
 
     $this->solrItems = new SolariumProxy('jitterbug-items');
     $this->solrInstances = new SolariumProxy('jitterbug-instances');
@@ -70,10 +72,14 @@ class AudioImport extends Import {
 
         // Validate that all required fields have values if this is a new record
         if ($new_record && empty($row[$key]) &&
-          in_array($key, $this->requiredAudioImportKeys)) {
+          in_array($key, $this->requiredAudioImportKeys, true)) {
           $bag->add($key, 'A value for ' . $key . ' is required.');
         }
-
+        // Validate call number exists if AV item fields are present and filled in
+        if (!$new_record && !empty($row[$key]) && empty($row['CallNumber']) &&
+          in_array($key, $this->avItemFieldKeys, true)) {
+          $bag->add($key, 'Call number must be filled in.');
+        }
         // Validate call number is audio
         if ($key === 'CallNumber'
           && !empty($row[$key]) && !$this->isAudio($row[$key])) {

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -180,17 +180,16 @@ class AudioImport extends Import {
       $departmentCache = array();
 
       foreach($this->data as $row) {
-        $callNumber = $row['CallNumber'];
+        // call number is allowed to be null if it's an update
+        $callNumber = $row['CallNumber'] ?? null;
 
         // We need to lookup the playback machine record to get the 
         // id. In order to avoid hitting the database, we will utilize
         // a simple cache.
-        $playbackMachineName = $row['PlaybackMachine'];
-        if (isset($playbackMachineName)) {
+        if (isset($row['PlaybackMachine'])) {
+          $playbackMachineName = $row['PlaybackMachine'];
           // Check the cache first for this playback machine record
-          $playbackMachine =
-            isset($playbackMachineCache[$playbackMachineName]) ?
-              $playbackMachineCache[$playbackMachineName] : null;
+          $playbackMachine = $playbackMachineCache[$playbackMachineName] ?? null;
           // Not in cache, so get from database and add to cache
           if ($playbackMachine === null) {
             $playbackMachine =
@@ -202,12 +201,10 @@ class AudioImport extends Import {
         }
 
         // Same as playback machine, we will use a cache for the department
-        $departmentName = $row['IART'];
-        if (isset($departmentName)) {
+        if (isset($row['IART'])) {
+          $departmentName = $row['IART'];
           // Check the cache first for this department record
-          $department =
-            isset($departmentCache[$departmentName]) ?
-              $departmentCache[$departmentName] : null;
+          $department = $departmentCache[$departmentName] ?? null;
           // Not in cache, so get from database and add to cache
           if ($department === null) {
             $department =
@@ -219,7 +216,7 @@ class AudioImport extends Import {
         }
 
         // Original PM is optional, so the column may not be present in the file
-        $originalPm = isset($row['OriginalPm']) ? $row['OriginalPm'] : null;
+        $originalPm = $row['OriginalPm'] ?? null;
         $duration = DurationFormat::toSeconds($row['Duration']);
         
         if (!empty($originalPm)) { 

--- a/app/Import/AudioImport.php
+++ b/app/Import/AudioImport.php
@@ -40,15 +40,15 @@ class AudioImport extends Import {
     $this->requiredAudioImportKeys = array('CallNumber', 
       'OriginatorReference', 'Side', 'PlaybackMachine', 'FileSize', 
       'Duration', 'OriginationDate', 'IART');
+    $this->avItemFieldKeys = array('Size', 'TrackConfiguration', 'Base', 'Speed');
     $this->audioImportKeys = array_merge($this->requiredAudioImportKeys, 
-      array('TransferNote', 'OriginalPm', 'Size', 'TrackConfiguration', 'Base', 'Speed'));
+      array('TransferNote', 'OriginalPm'), $this->avItemFieldKeys);
     $this->mustAlreadyExistInDbKeys = array(
       'Size' => AudioItem::class,
       'TrackConfiguration' => AudioItem::class,
       'Base' => AudioItem::class,
       'Speed' => AudioVisualItem::class
     );
-    $this->avItemFieldKeys = array('Size', 'TrackConfiguration', 'Base', 'Speed');
 
     $this->solrItems = new SolariumProxy('jitterbug-items');
     $this->solrInstances = new SolariumProxy('jitterbug-instances');

--- a/tests/Feature/TransferAudioImportsTest.php
+++ b/tests/Feature/TransferAudioImportsTest.php
@@ -6,6 +6,7 @@ use Jitterbug\Models\User;
 use Jitterbug\Models\Department;
 use Jitterbug\Models\AudioItem;
 use Jitterbug\Models\PlaybackMachine;
+use Jitterbug\Models\PreservationInstance;
 
 class TransferAudioImportsTest extends TestCase
 {
@@ -14,63 +15,63 @@ class TransferAudioImportsTest extends TestCase
      *
      * @return void
      */
-    use RefreshDatabase;
-    private $user;
-    private $audioVisualItem1;
-    private $audioVisualItem2;
-    private $department;
-    private $playbackMachine;
+  use RefreshDatabase;
+  private $user;
+  private $audioVisualItem1;
+  private $audioVisualItem2;
+  private $department;
+  private $playbackMachine;
 
-    protected function setUp() : void
-    {
-      parent::setUp();
-      $this->user = User::factory()->create();
-      $this->department = Department::factory()->create(['name' => 'SFC']);
-      $this->audioVisualItem1 = AudioVisualItem::factory()->create(['call_number' =>'FT-6708']);
-      $this->audioVisualItem2 = AudioVisualItem::factory()->create(['call_number' =>'FT-6709']);
-      $this->playbackMachine = PlaybackMachine::factory()->create(['name' => 'Otari 19462235 D']);
-      AudioItem::factory()->create(['size' => '7"', 'track_configuration' => '1/2 track', 'base' => 'Polyester']);
-      AudioVisualItem::factory()->create(['speed' => '78 rpm']);
-    }
+  protected function setUp() : void
+  {
+    parent::setUp();
+    $this->user = User::factory()->create();
+    $this->department = Department::factory()->create(['name' => 'SFC']);
+    $this->audioVisualItem1 = AudioVisualItem::factory()->create(['call_number' =>'FT-6708']);
+    $this->audioVisualItem2 = AudioVisualItem::factory()->create(['call_number' =>'FT-6709']);
+    $this->playbackMachine = PlaybackMachine::factory()->create(['name' => 'Otari 19462235 D']);
+    AudioItem::factory()->create(['size' => '7"', 'track_configuration' => '1/2 track', 'base' => 'Polyester']);
+    AudioVisualItem::factory()->create(['speed' => '78 rpm']);
+  }
 
-    public function testAudioImportUpload()
-    {
-      $user = $this->user;
-      $filePath = base_path('tests/import-test-files/audio-import/sample_audio_import_missing_original_pm_column.csv');
-      $file = $this->getUploadableFile($filePath, 'sample_audio_import.csv', 'text/csv');
+  public function testAudioImportUpload() : void
+  {
+    $user = $this->user;
+    $filePath = base_path('tests/import-test-files/audio-import/sample_audio_import_missing_original_pm_column.csv');
+    $file = $this->getUploadableFile($filePath, 'sample_audio_import.csv', 'text/csv');
 
-      $this->actingAs($user)->post(
-        '/transfers/batch/audio-import-upload',
-        ['audio-import-file' => $file,],
-        array('HTTP_X-Requested-With' => 'XMLHttpRequest')
-      );
+    $this->actingAs($user)->post(
+      '/transfers/batch/audio-import-upload',
+      ['audio-import-file' => $file,],
+      array('HTTP_X-Requested-With' => 'XMLHttpRequest')
+    );
 
-      $path = storage_path('app/uploads');
-      $filename = $user->username . '-audio-import-' . fileTimestamp();
+    $path = storage_path('app/uploads');
+    $filename = $user->username . '-audio-import-' . fileTimestamp();
 
-      $this->assertFileExists("{$path}/{$filename}.csv");
-    }
+    $this->assertFileExists("{$path}/{$filename}.csv");
+  }
 
-    public function testAudioImportUploadExecuteWithErrors()
-    {
-      $user = $this->user;
-      $filePath = base_path('tests/import-test-files/audio-import/small_import_non_validated.csv');
+  public function testAudioImportUploadExecuteWithErrors() : void
+  {
+    $user = $this->user;
+    $filePath = base_path('tests/import-test-files/audio-import/small_import_non_validated.csv');
 
-      $response = $this->actingAs($user)
-                       ->withSession(['audio-import-file' => $filePath])
-                       ->post('/transfers/batch/audio-import-execute',
-                         [],
-                         array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
+    $response = $this->actingAs($user)
+                     ->withSession(['audio-import-file' => $filePath])
+                     ->post('/transfers/batch/audio-import-execute',
+                       [],
+                       array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
 
-      $responseArray = json_decode($response->getContent(), true);
-      // see if the response html includes the uploaded file error string
-      $htmlContainsErrorMessage = strpos($responseArray['html'], 'There are errors in your uploaded file.') !== false;
+    $responseArray = json_decode($response->getContent(), true);
+    // see if the response html includes the uploaded file error string
+    $htmlContainsErrorMessage = strpos($responseArray['html'], 'There are errors in your uploaded file.') !== false;
 
-      $this->assertEquals('error', $responseArray['status'], "The JSON status should be 'error'.");
-      $this->assertTrue($htmlContainsErrorMessage, 'The HTML in the response does not include the correct error notification.');
-    }
+    $this->assertEquals('error', $responseArray['status'], "The JSON status should be 'error'.");
+    $this->assertTrue($htmlContainsErrorMessage, 'The HTML in the response does not include the correct error notification.');
+  }
 
-    public function testAudioImportUploadExecuteWithSuccess()
+  public function testAudioImportUploadExecuteWithSuccess() : void
     {
       $user = $this->user;
       $filePath = base_path('tests/import-test-files/audio-import/small_upload_file_no_errors.csv');
@@ -89,7 +90,7 @@ class TransferAudioImportsTest extends TestCase
       $this->assertTrue($htmlContainsSuccessMessage, 'The HTML in the response does not include the correct success notification.');
     }
 
-  public function testAudioImportUploadUpdateSizeWithSuccess()
+  public function testAudioImportUploadUpdateSizeWithSuccess() : void
   {
     $user = $this->user;
     $avItem = $this->audioVisualItem1;
@@ -108,7 +109,7 @@ class TransferAudioImportsTest extends TestCase
     $this->assertEquals('7"', $audioItem->size, 'The size column in the related AudioItem was not set correctly.');
   }
 
-  public function testAudioImportUploadUpdateTrackConfigWithSuccess()
+  public function testAudioImportUploadUpdateTrackConfigWithSuccess() : void
   {
     $user = $this->user;
     $avItem = $this->audioVisualItem1;
@@ -128,7 +129,7 @@ class TransferAudioImportsTest extends TestCase
       'The track configuration column in the related AudioItem was not set correctly.');
   }
 
-  public function testAudioImportUploadUpdateBaseWithSuccess()
+  public function testAudioImportUploadUpdateBaseWithSuccess() : void
   {
     $user = $this->user;
     $avItem = $this->audioVisualItem1;
@@ -148,7 +149,7 @@ class TransferAudioImportsTest extends TestCase
       'The base column in the related AudioItem was not set correctly.');
   }
 
-  public function testAudioImportUploadUpdateSpeedWithSuccess()
+  public function testAudioImportUploadUpdateSpeedWithSuccess() : void
   {
     $user = $this->user;
     $avItem = $this->audioVisualItem1;
@@ -165,5 +166,26 @@ class TransferAudioImportsTest extends TestCase
     $this->assertEquals('success', $responseArray['status'], "The JSON status should be 'success'.");
     $this->assertEquals('78 rpm', $avItemInDb->speed,
       'The speed column in the AudioVisualItem entry was not set correctly.');
+  }
+
+  public function testAudioImportUploadUpdateWithUnusedHeadersMissing() : void
+  {
+    $user = $this->user;
+    PreservationInstance::factory()->create(['id' => 82143, 'call_number' => 'FT-6708']);
+    PreservationInstance::factory()->create(['id' => 81073, 'call_number' => 'FT-6708']);
+    $filePath = base_path('tests/import-test-files/audio-import/sample_audio_import_update_missing_headers.csv');
+
+    $response = $this->actingAs($user)
+      ->withSession(['audio-import-file' => $filePath])
+      ->post('/transfers/batch/audio-import-execute',
+        [],
+        array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
+
+    $responseArray = json_decode($response->getContent(), true);
+    $htmlContainsSuccessMessage = strpos($responseArray['html'], 'Your import was successful!') !== false;
+
+
+    $this->assertEquals('success', $responseArray['status'], "The JSON status should be 'success'.");
+    $this->assertTrue($htmlContainsSuccessMessage, 'The HTML in the response does not include the correct success notification.');
   }
 }

--- a/tests/Feature/TransferAudioImportsTest.php
+++ b/tests/Feature/TransferAudioImportsTest.php
@@ -192,7 +192,7 @@ class TransferAudioImportsTest extends TestCase
   public function testAudioImportUploadUpdateDoesNotUpdateBlankValues() : void
   {
     $user = $this->user;
-    $preservationInstance =PreservationInstance::factory()->create(['id' => 82143, 'call_number' => 'FT-6708']);
+    $preservationInstance = PreservationInstance::factory()->create(['id' => 82143, 'call_number' => 'FT-6708']);
     $originalFileName = $preservationInstance->file_name;
     PreservationInstance::factory()->create(['id' => 81073]);
     PlaybackMachine::factory()->create(['name' => 'Otari']);

--- a/tests/import-test-files/audio-import/sample_audio_import_update_missing_headers.csv
+++ b/tests/import-test-files/audio-import/sample_audio_import_update_missing_headers.csv
@@ -1,0 +1,3 @@
+OriginalPm,CallNumber,OriginatorReference,PlaybackMachine,FileSize,Duration,OriginationDate
+82143,FT-6708,,Otari,393024830294839000,20:30:01,
+81073,,05413_C2_1_PM,Otari,,,2020-02-03


### PR DESCRIPTION
This PR fixes/actually allows there to be missing headers when the audio import is an update (instead of making new records). There was already logic in the validations for this, but the execution step still depended on the existence of the required fields when processing the CSV.

This PR:
- checks to see if required fields are set, first
- adds a validation that if AV item fields are filled, call number field must also exist and be filled in
- adds two tests
- fixes some spacing in the tests file