### PR TITLE
Appdev 10195 fix dusk

### DIFF
--- a/.env.dusk.testing
+++ b/.env.dusk.testing
@@ -1,9 +1,10 @@
-APP_ENV=local
+APP_ENV=testing
 APP_DEBUG=true
 APP_KEY=27ceqUDGvdm77abRFSNQbFSVFIz4dGIH
 APP_URL=http://homestead.test
 
 DB_HOST=127.0.0.1
+DB_PORT=3306
 DB_DATABASE=jitterbug_testing
 DB_USERNAME=homestead
 DB_PASSWORD=secret

--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -19,3 +19,5 @@ databases:
     - homestead
 name: jitterbug
 hostname: jitterbug
+features:
+    - webdriver: true

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ $ npm run dev
     ```
 3. Run the Laravel Dusk tests
     ```bash
-    php artisan dusk
+    php artisan dusk --env=testing
     ```
 4. Check screenshots folder when there's a failure in `tests/Browser/screenshots`
 


### PR DESCRIPTION
This PR details a few config changes to make sure that Dusk is using the testing DB when run. It also adds necessary changes to Homestead.yaml.example so that Dusk can be run after setting up a new VM.