### PR TITLE
APPDEV-10223 removing preservation instances that are deleted from be…

### DIFF
--- a/solrconfig/jitterbug-items/conf/solr-data-config.xml
+++ b/solrconfig/jitterbug-items/conf/solr-data-config.xml
@@ -39,7 +39,8 @@
             LEFT JOIN media_types AS types ON
                 TRIM(TRAILING 'Item' FROM items.subclass_type) = types.name
             LEFT JOIN preservation_instances ON
-                items.call_number = preservation_instances.call_number
+                items.call_number = preservation_instances.call_number AND
+                preservation_instances.deleted_at is null
             WHERE
                 items.deleted_at is null;
 


### PR DESCRIPTION
…ing considered for the digitized filter

It was noticed that Solr was pulling in soft-deleted preservation instances when determining if an AV item was digitized. This caused inaccurate results, because those PIs don't actually exist. This PR fixes that when joining to the preservation_instances table.