### PR TITLE
Appdev 9782 validation and error handling for admin users

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -3,7 +3,6 @@
 use Auth;
 use DB;
 use Illuminate\Support\MessageBag;
-use Log;
 
 use Illuminate\Http\Request;
 
@@ -37,7 +36,7 @@ class AdminController extends Controller
       if ($user->inactive === 0) {
         $user->admin = 1;
         $user->save();
-        return response()->json(['status'=>'success']);
+        return response()->json(['status'=>'success'], 200);
       }
       $bag = new MessageBag();
       $bag->add('status', 'That user is inactive, so they cannot be made admin.');
@@ -53,6 +52,7 @@ class AdminController extends Controller
       $user = User::where('username', $username)->first();
       $user->admin = 0;
       $user->save();
+      return response()->json(['status'=>'success'], 200);
     }
   }
 

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -2,6 +2,7 @@
 
 use Auth;
 use DB;
+use Illuminate\Support\MessageBag;
 use Log;
 
 use Illuminate\Http\Request;
@@ -33,8 +34,14 @@ class AdminController extends Controller
       $input = $request->all();
       $username = $input['username'];
       $user = User::where('username', $username)->first();
-      $user->admin = 1;
-      $user->save();
+      if ($user->inactive === 0) {
+        $user->admin = 1;
+        $user->save();
+        return response()->json(['status'=>'success']);
+      }
+      $bag = new MessageBag();
+      $bag->add('status', 'That user is inactive, so they cannot be made admin.');
+      return response()->json($bag, 422);
     }
   }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -161,16 +161,30 @@ jitterbug = {
     adminCheckboxes.click(function(event) {
       var makeAdmin = $(this).is(':checked');
       var route = makeAdmin ? '/admin/make-admin'
-          : '/admin/remove-admin';
+        : '/admin/remove-admin';
       var data = {};
       var username = $(this).data('username');
       data['username'] = username;
-      $.post(route, data, function(data) {
+      $.post(route, data, function (data) {
         var message = makeAdmin
-            ? 'User ' + username + ' was successfully made admin.'
-            : 'User ' + username + ' is no longer an admin.';
+          ? 'User ' + username + ' was successfully made admin.'
+          : 'User ' + username + ' is no longer an admin.';
         $(window).scrollTop(0);
         jitterbug.displayAlert('success', message);
+      })
+      .fail(function (jqXHR) {
+        // Validation error
+        if (jqXHR.status == 422) {
+          var errors = JSON.parse(jqXHR.responseText);
+          var errorMessage = errors['errors']['name'][0];
+          // Get the first error, no matter which it is.
+
+          // Unfortunately, we have to hide the popover here
+          // because it doesn't stay pinned to the field it
+          // relates to when the alert div is opened (a bug
+          // in Bootstrap/Tether).
+          jitterbug.displayAlert('danger', '<strong>Whoops.</strong> ' + errorMessage);
+        }
       });
     });
   },

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class AdminTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function test_example() : void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -1,23 +1,65 @@
 <?php
 
-namespace Tests\Feature;
-
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
+use Jitterbug\Models\User;
+use Illuminate\Support\Facades\Log;
 
 class AdminTest extends TestCase
 {
   use RefreshDatabase;
-  /**
-   * A basic feature test example.
-   *
-   * @return void
-   */
-  public function test_example() : void
-  {
-      $response = $this->get('/');
+  private $adminUser;
 
-      $response->assertStatus(200);
+  protected function setUp(): void
+  {
+    parent::setUp();
+    $this->adminUser = User::factory()->create(['admin' => 1]);
+  }
+
+  public function testUserIsMadeAdminAppropriately() : void
+  {
+    $regularUser = User::factory()->create(['inactive' => 0, 'admin' => 0]);
+    $adminUser = $this->adminUser;
+    $this->be($adminUser);
+
+    $response = $this->post('/admin/make-admin',
+      [
+        'username' => $regularUser->username,
+      ],
+      array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
+
+    $this->assertEquals(1, User::find($regularUser->id)->admin);
+    $response->assertSuccessful();
+  }
+
+  public function testInactiveUserIsNotMadeAdmin() : void
+  {
+    $inactiveUser = User::factory()->create(['inactive' => 1]);
+    $adminUser = $this->adminUser;
+    $this->be($adminUser);
+
+    $response = $this->post('/admin/make-admin',
+      [
+        'username' => $inactiveUser->username,
+      ],
+      array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
+
+    $this->assertEquals(0, User::find($inactiveUser->id)->admin);
+    $response->assertStatus(422);
+  }
+
+  public function testAdminUserHasAdminStatusRemovedAppropriately() : void
+  {
+    $adminUser1 = User::factory()->create(['admin' => 1]);
+    $adminUser = $this->adminUser;
+    $this->be($adminUser);
+
+    $response = $this->post('/admin/remove-admin',
+      [
+        'username' => $adminUser1->username,
+      ],
+      array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
+
+    $this->assertEquals(0, User::find($adminUser1->id)->admin);
+    $response->assertSuccessful();
   }
 }

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -8,15 +8,16 @@ use Tests\TestCase;
 
 class AdminTest extends TestCase
 {
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
-    public function test_example() : void
-    {
-        $response = $this->get('/');
+  use RefreshDatabase;
+  /**
+   * A basic feature test example.
+   *
+   * @return void
+   */
+  public function test_example() : void
+  {
+      $response = $this->get('/');
 
-        $response->assertStatus(200);
-    }
+      $response->assertStatus(200);
+  }
 }


### PR DESCRIPTION
This PR implements a controller check to make sure that inactive users cannot be made admin. This is already precluded by the front-end, but having a back end check makes it more secure.