### PR TITLE
Batch editing fix

### DIFF
--- a/app/Models/BatchAudioVisualItem.php
+++ b/app/Models/BatchAudioVisualItem.php
@@ -21,12 +21,14 @@ class BatchAudioVisualItem extends AudioVisualItem
 
     public function __construct($items, $subclasses)
     {
-        parent::__construct();
+        // Remove parent__construct call as it seems to also be called when instantiating the
+        // AudioVisualItem class in the batch constructor, which the batch class inherits from
+        // parent::__construct();
 
         $this->items = $items;
         $this->subclasses = $subclasses;
 
-        $this->aggregateItem = new AudioVIsualItem;
+        $this->aggregateItem = new AudioVisualItem;
         $this->aggregateItem->entry_date = null;
         $subclassType = $this->items->first()->subclass_type;
         $this->aggregateItem->subclass_type = $subclassType;

--- a/app/Models/BatchPreservationInstance.php
+++ b/app/Models/BatchPreservationInstance.php
@@ -23,7 +23,9 @@ class BatchPreservationInstance extends PreservationInstance
 
     public function __construct($instances, $subclasses)
     {
-        parent::__construct();
+        // IRemove parent__construct call as it seems to also be called when instantiating the
+        // PreservationInstance class in the batch constructor, which the batch class inherits from
+        // parent::__construct();
 
         $this->instances = $instances;
         $this->subclasses = $subclasses;

--- a/app/Models/BatchTransfer.php
+++ b/app/Models/BatchTransfer.php
@@ -21,7 +21,9 @@ class BatchTransfer extends Transfer
 
     public function __construct($transfers, $subclasses)
     {
-        parent::__construct();
+        // Remove parent__construct call as it seems to also be called when instantiating
+        // the Transfer class in the batch constructor, which the batch class inherits from
+        // parent::__construct();
 
         $this->transfers = $transfers;
         $this->subclasses = $subclasses;


### PR DESCRIPTION
Remove parent__construct call as it seems to also be called when instantiating the specific item type class in the batch constructor, which the batch class inherits from.

https://unclibrary.atlassian.net/browse/APPDEV-11453