### PR TITLE
fix sort order and minimize DB calls

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,6 +34,6 @@ class Kernel extends ConsoleKernel
       ->everyMinute()
       ->timezone('America/New_York')
       ->between('7:00', '18:00')
-      ->withoutOverlapping(2);
+      ->withoutOverlapping(15);
     }
 }

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -77,19 +77,24 @@ class ActivityStream
                                      ->get()->all();
 
         $lastRevisionTransactionId = $results[0]->transaction_id;
+        Log::error('last revision transaction ID is {id}', ['id' => $lastRevisionTransactionId]);
 
         // Fetch most recent transaction in the activities table
         // The smallest ID is the most recently done activity
         $results = DB::table('activities')->select('transaction_id')
-                                      ->orderBy('id')
+                                      ->orderBy('id', 'asc')
                                       ->limit(1)
                                       ->get()->all();
+
         if (count($results) === 0) {
+            Log::error("count is empty, return true");
             return true;
         }
 
         $lastActivityTransactionId = $results[0]->transaction_id;
-
+        Log::error('last activity transaction ID is {id}', ['id' => $lastActivityTransactionId]);
+        $hasNew = $lastRevisionTransactionId !== $lastActivityTransactionId;
+        Log::error("has new is {hasNew}", ['hasNew' => $hasNew]);
         return $lastRevisionTransactionId !== $lastActivityTransactionId;
     }
 }

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -71,7 +71,7 @@ class ActivityStream
     {
         // Fetch last transaction in the revisions table
         $results = DB::table('revisions')->select('transaction_id')
-                                     ->orderBy('id')
+                                     ->orderBy('id', 'desc')
                                      ->limit(1)
                                      ->get()->all();
 

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -78,7 +78,6 @@ class ActivityStream
                                      ->get()->all();
 
         $lastRevisionTransactionId = $results[0]->transaction_id;
-        Log::error('last revision transaction ID is {id}', ['id' => $lastRevisionTransactionId]);
 
         // Fetch most recent transaction in the activities table
         // The smallest ID is the most recently done activity
@@ -88,14 +87,11 @@ class ActivityStream
                                       ->get()->all();
 
         if (count($results) === 0) {
-            Log::error("count is empty, return true");
             return true;
         }
 
         $lastActivityTransactionId = $results[0]->transaction_id;
-        Log::error('last activity transaction ID is {id}', ['id' => $lastActivityTransactionId]);
-        $hasNew = $lastRevisionTransactionId !== $lastActivityTransactionId;
-        Log::error("has new is {hasNew}", ['hasNew' => $hasNew]);
+
         return $lastRevisionTransactionId !== $lastActivityTransactionId;
     }
 }

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -4,6 +4,7 @@ namespace Jitterbug\Presenters;
 
 use DB;
 use Jitterbug\Models\Activity;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Models a stream of recent activity, culled from the revisions table.

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -69,7 +69,7 @@ class ActivityStream
 
     private function hasNewTransactions(): bool
     {
-        // Fetch last transaction in the revisions table
+        // Fetch last transaction made in the revisions table
         $results = DB::table('revisions')->select('transaction_id')
                                      ->orderBy('id', 'desc')
                                      ->limit(1)
@@ -77,7 +77,7 @@ class ActivityStream
 
         $lastRevisionTransactionId = $results[0]->transaction_id;
 
-        // Fetch last transaction in the activities table
+        // Fetch most recent transaction in the activities table
         $results = DB::table('activities')->select('transaction_id')
                                       ->orderBy('id')
                                       ->limit(1)

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -4,7 +4,6 @@ namespace Jitterbug\Presenters;
 
 use DB;
 use Jitterbug\Models\Activity;
-use Illuminate\Support\Facades\Log;
 
 /**
  * Models a stream of recent activity, culled from the revisions table.

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -4,6 +4,7 @@ namespace Jitterbug\Presenters;
 
 use DB;
 use Jitterbug\Models\Activity;
+use 
 
 /**
  * Models a stream of recent activity, culled from the revisions table.
@@ -70,13 +71,12 @@ class ActivityStream
     private function hasNewTransactions(): bool
     {
         // Fetch last transaction in the revisions table
-        // $results = DB::table('revisions')->select('transaction_id')
-        //                              ->orderBy('id', 'desc')
-        //                              ->limit(1)
-        //                              ->get()->all();
-        $lastRevisionTransactionId = Revision::latest('id')->first()->transaction_id;
+        $results = DB::table('revisions')->select('transaction_id')
+                                     ->orderBy('id', 'desc')
+                                     ->limit(1)
+                                     ->get()->all();
 
-        // $lastRevisionTransactionId = $results[0]->transaction_id;
+        $lastRevisionTransactionId = $results[0]->transaction_id;
 
         // Fetch last transaction in the activities table
         $results = DB::table('activities')->select('transaction_id')

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -70,6 +70,7 @@ class ActivityStream
     private function hasNewTransactions(): bool
     {
         // Fetch last transaction made in the revisions table
+        // Each batch of revisions will have the same transaction ID
         $results = DB::table('revisions')->select('transaction_id')
                                      ->orderBy('id', 'desc')
                                      ->limit(1)
@@ -78,6 +79,7 @@ class ActivityStream
         $lastRevisionTransactionId = $results[0]->transaction_id;
 
         // Fetch most recent transaction in the activities table
+        // The smallest ID is the most recently done activity
         $results = DB::table('activities')->select('transaction_id')
                                       ->orderBy('id')
                                       ->limit(1)

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -70,12 +70,13 @@ class ActivityStream
     private function hasNewTransactions(): bool
     {
         // Fetch last transaction in the revisions table
-        $results = DB::table('revisions')->select('transaction_id')
-                                     ->orderBy('id', 'desc')
-                                     ->limit(1)
-                                     ->get()->all();
+        // $results = DB::table('revisions')->select('transaction_id')
+        //                              ->orderBy('id', 'desc')
+        //                              ->limit(1)
+        //                              ->get()->all();
+        $lastRevisionTransactionId = Revision::latest('id')->first()->transaction_id;
 
-        $lastRevisionTransactionId = $results[0]->transaction_id;
+        // $lastRevisionTransactionId = $results[0]->transaction_id;
 
         // Fetch last transaction in the activities table
         $results = DB::table('activities')->select('transaction_id')

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -4,7 +4,6 @@ namespace Jitterbug\Presenters;
 
 use DB;
 use Jitterbug\Models\Activity;
-use 
 
 /**
  * Models a stream of recent activity, culled from the revisions table.

--- a/app/Presenters/ActivityStream.php
+++ b/app/Presenters/ActivityStream.php
@@ -47,7 +47,7 @@ class ActivityStream
                 }
 
                 // Delete all activities
-                Activity::truncate();
+                Activity::query()->delete();
 
                 // Insert activities into the database
                 foreach ($activities as $activity) {

--- a/app/Presenters/TransactionDigest.php
+++ b/app/Presenters/TransactionDigest.php
@@ -367,14 +367,14 @@ class TransactionDigest
         }
         $firstRev = $this->revisions->first();
         $class = $firstRev->revisionable_type;
-        $instance =
-      $class::withTrashed()->findOrFail($firstRev->revisionable_id);
+        $instance = $class::withTrashed()->findOrFail($firstRev->revisionable_id);
         if (! array_key_exists($firstRev->revisionable_type, $this->baseClasses)) {
             $instance = $instance->superclass;
         }
         $this->associatedItem = AudioVisualItem::withTrashed()
-      ->where('call_number', $instance->call_number)
-      ->first();
+            ->where('call_number', $instance->call_number)
+            ->last();
+        $this->associatedCallNumber = $instance->call_number;
 
         return $this->associatedItem;
     }
@@ -391,9 +391,15 @@ class TransactionDigest
         if ($this->associatedItemType) {
             return $this->associatedItemType;
         }
+
+        if ($this->associatedItem) {
+            $this->associatedItemType = strtolower($this->associatedItem->type);
+            return $this->associatedItemType;
+        }
+
         $item = AudioVisualItem::withTrashed()
-      ->where('call_number', $this->findAssociatedCallNumber())
-      ->first();
+            ->where('call_number', $this->associatedCallNumber)
+            ->last();
         if ($item !== null) {
             $this->associatedItem = $item;
             $this->associatedItemType = strtolower($item->type);
@@ -415,8 +421,7 @@ class TransactionDigest
         }
         $firstRev = $this->revisions->first();
         $class = $firstRev->revisionable_type;
-        $instance =
-      $class::withTrashed()->findOrFail($firstRev->revisionable_id);
+        $instance = $class::withTrashed()->findOrFail($firstRev->revisionable_id);
         if (! array_key_exists($firstRev->revisionable_type, $this->baseClasses)) {
             $instance = $instance->superclass;
         }
@@ -449,8 +454,7 @@ class TransactionDigest
     protected function wasUpdate()
     {
         foreach ($this->revisions as $revision) {
-            if ($revision->field === 'created_at' ||
-          $revision->field === 'deleted_at') {
+            if ($revision->field === 'created_at' || $revision->field === 'deleted_at') {
                 return false;
             }
         }

--- a/app/Presenters/TransactionDigest.php
+++ b/app/Presenters/TransactionDigest.php
@@ -373,7 +373,8 @@ class TransactionDigest
         }
         $this->associatedItem = AudioVisualItem::withTrashed()
             ->where('call_number', $instance->call_number)
-            ->last();
+            ->orderBy('id', 'desc')
+            ->first();
         $this->associatedCallNumber = $instance->call_number;
 
         return $this->associatedItem;
@@ -399,7 +400,8 @@ class TransactionDigest
 
         $item = AudioVisualItem::withTrashed()
             ->where('call_number', $this->associatedCallNumber)
-            ->last();
+            ->orderBy('id', 'desc')
+            ->first();
         if ($item !== null) {
             $this->associatedItem = $item;
             $this->associatedItemType = strtolower($item->type);


### PR DESCRIPTION
This PR does the following:
- adding descending sort order to revisions query
- removing one method call to find the call number to use already set value
- changing query to find the last AV item instead of the first
- updating spacing/indentation
- update truncate to delete